### PR TITLE
Add custom domain support via Cloudflare Worker reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ cs-serve file payload.bin                               # serve a file
 cs-serve redirect http://169.254.169.254/metadata/      # SSRF redirect
 cs-serve custom 9999 '{"pwned":true}' application/json  # custom response
 cs-serve capture                                        # capture POST data
+cs-serve -d dev.example.com file payload.bin            # custom domain via Cloudflare
 ```
 
 ### WireGuard VPN

--- a/csproxy/cli.py
+++ b/csproxy/cli.py
@@ -116,6 +116,7 @@ def main_serve(argv=None):
         description='GitHub Codespaces File Server - serve files with public URLs',
     )
     parser.add_argument('-c', '--codespace', help='Codespace name to use')
+    parser.add_argument('-d', '--domain', help='Custom domain via Cloudflare Worker')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
 
     subparsers = parser.add_subparsers(dest='command', help='Serve mode')

--- a/csproxy/cloudflare.py
+++ b/csproxy/cloudflare.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Cloudflare Worker management for cs-serve custom domain proxying.
+
+Deploys and tears down Cloudflare Workers that reverse-proxy traffic
+from a custom domain to a Codespace's app.github.dev URL.
+"""
+
+import json
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+from .utils import get_logger
+
+# Cloudflare API base URL
+CF_API_BASE = "https://api.cloudflare.com/client/v4"
+
+# Worker script template — {CODESPACE_URL} is replaced at deploy time
+WORKER_SCRIPT_TEMPLATE = """\
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    url.hostname = "{CODESPACE_URL}";
+    const newRequest = new Request(url.toString(), {
+      method: request.method,
+      headers: new Headers(request.headers),
+      body: request.body,
+      redirect: "follow"
+    });
+    newRequest.headers.set("Host", "{CODESPACE_URL}");
+    return fetch(newRequest);
+  },
+};
+"""
+
+
+def generate_worker_script(codespace_url: str) -> str:
+    """
+    Generate a Cloudflare Worker script for the given Codespace URL.
+
+    Args:
+        codespace_url: The Codespace hostname (e.g., 'name-9999.app.github.dev')
+
+    Returns:
+        The complete Worker JavaScript source code.
+    """
+    return WORKER_SCRIPT_TEMPLATE.replace("{CODESPACE_URL}", codespace_url)
+
+
+class CloudflareWorker:
+    """Manages Cloudflare Worker deployment and teardown via REST API."""
+
+    def __init__(self, api_token: str, account_id: str):
+        """
+        Args:
+            api_token: Cloudflare API token with Workers permissions
+            account_id: Cloudflare account ID
+        """
+        self.api_token = api_token
+        self.account_id = account_id
+        self.logger = get_logger()
+        self._deployed_name = None
+
+    def deploy(self, worker_name: str, codespace_url: str) -> str:
+        """
+        Deploy a Worker script that proxies to the Codespace URL.
+
+        Args:
+            worker_name: Name for the worker (e.g., 'cs-serve-9999')
+            codespace_url: Target Codespace hostname
+
+        Returns:
+            The worker's default URL (worker_name.account-subdomain.workers.dev)
+        """
+        script = generate_worker_script(codespace_url)
+
+        self.logger.info(f"Deploying Cloudflare Worker: {worker_name}")
+        self.logger.info(f"  Target: {codespace_url}")
+
+        self._api_request(
+            "PUT",
+            f"/accounts/{self.account_id}/workers/scripts/{worker_name}",
+            data=script.encode("utf-8"),
+            content_type="application/javascript",
+        )
+
+        self._deployed_name = worker_name
+        self.logger.info(f"Worker deployed: {worker_name}")
+        return worker_name
+
+    def add_custom_domain(self, worker_name: str, domain: str) -> None:
+        """
+        Bind a custom domain to the deployed worker.
+
+        The domain must be on a zone in the same Cloudflare account.
+
+        Args:
+            worker_name: Name of the deployed worker
+            domain: Custom domain to bind (e.g., 'dev.example.com')
+        """
+        self.logger.info(f"Binding custom domain: {domain} -> {worker_name}")
+
+        payload = {
+            "hostname": domain,
+            "service": worker_name,
+            "environment": "production",
+        }
+
+        self._api_request(
+            "PUT",
+            f"/accounts/{self.account_id}/workers/domains",
+            data=json.dumps(payload).encode("utf-8"),
+            content_type="application/json",
+        )
+
+        self.logger.info(f"Custom domain bound: {domain}")
+
+    def teardown(self, worker_name: str = None) -> None:
+        """
+        Delete a Worker script from Cloudflare.
+
+        Args:
+            worker_name: Name of the worker to delete (defaults to last deployed)
+        """
+        name = worker_name or self._deployed_name
+        if not name:
+            return
+
+        self.logger.info(f"Tearing down Cloudflare Worker: {name}")
+
+        try:
+            self._api_request(
+                "DELETE",
+                f"/accounts/{self.account_id}/workers/scripts/{name}",
+            )
+            self.logger.info(f"Worker deleted: {name}")
+        except Exception as e:
+            self.logger.warning(f"Failed to delete worker {name}: {e}")
+
+        self._deployed_name = None
+
+    def _api_request(self, method: str, endpoint: str,
+                     data: bytes = None, content_type: str = None) -> dict:
+        """
+        Make an authenticated request to the Cloudflare API.
+
+        Args:
+            method: HTTP method (GET, PUT, POST, DELETE)
+            endpoint: API path (e.g., '/accounts/{id}/workers/scripts/{name}')
+            data: Request body bytes
+            content_type: Content-Type header value
+
+        Returns:
+            Parsed JSON response (or empty dict for DELETE)
+
+        Raises:
+            urllib.error.HTTPError: On API errors
+        """
+        url = f"{CF_API_BASE}{endpoint}"
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.api_token}")
+
+        if content_type:
+            req.add_header("Content-Type", content_type)
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read().decode("utf-8")
+                if body:
+                    return json.loads(body)
+                return {}
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8", errors="replace")
+            self.logger.error(f"Cloudflare API error ({e.code}): {error_body}")
+            raise
+
+
+def setup_worker(codespace_url: str, domain: str, config) -> CloudflareWorker:
+    """
+    Deploy a Cloudflare Worker if credentials are available, otherwise
+    generate the script and save it locally.
+
+    Args:
+        codespace_url: Target Codespace hostname (e.g., 'name-9999.app.github.dev')
+        domain: Custom domain to bind
+        config: Config object with Cloudflare credentials
+
+    Returns:
+        CloudflareWorker instance if deployed, None if script was generated only
+    """
+    logger = get_logger()
+    api_token = config.get('cloudflare_api_token', '')
+    account_id = config.get('cloudflare_account_id', '')
+
+    port = codespace_url.split("-")[-1].split(".")[0]
+    worker_name = f"cs-serve-{port}"
+
+    if api_token and account_id:
+        # Auto-deploy mode
+        cf = CloudflareWorker(api_token, account_id)
+        cf.deploy(worker_name, codespace_url)
+        cf.add_custom_domain(worker_name, domain)
+        return cf
+    else:
+        # Generate-only mode
+        script = generate_worker_script(codespace_url)
+
+        # Save to file
+        script_path = Path("worker.js")
+        script_path.write_text(script)
+
+        logger.info(f"Worker script saved to: {script_path.absolute()}")
+        print(f"\n{'=' * 60}")
+        print("Cloudflare Worker Script (manual deployment)")
+        print(f"{'=' * 60}\n")
+        print("No Cloudflare credentials found. Set these environment variables")
+        print("for automatic deployment:\n")
+        print("  export CLOUDFLARE_API_TOKEN='your-api-token'")
+        print("  export CLOUDFLARE_ACCOUNT_ID='your-account-id'\n")
+        print(f"Worker script saved to: {script_path.absolute()}\n")
+        print("Manual setup:")
+        print("  1. Go to Cloudflare Dashboard > Workers & Pages > Create")
+        print(f"  2. Name it '{worker_name}' and deploy")
+        print("  3. Edit code, paste contents of worker.js, save and deploy")
+        print(f"  4. Add custom domain: {domain}\n")
+        print(f"{'=' * 60}\n")
+
+        return None
+
+
+def teardown_worker(port: int, config) -> None:
+    """
+    Tear down a Cloudflare Worker for the given port if credentials are available.
+
+    Args:
+        port: Port number (used to derive worker name cs-serve-{port})
+        config: Config object with Cloudflare credentials
+    """
+    api_token = config.get('cloudflare_api_token', '')
+    account_id = config.get('cloudflare_account_id', '')
+
+    if not api_token or not account_id:
+        return
+
+    worker_name = f"cs-serve-{port}"
+    cf = CloudflareWorker(api_token, account_id)
+    cf.teardown(worker_name)

--- a/csproxy/serve.py
+++ b/csproxy/serve.py
@@ -354,12 +354,16 @@ def _show_banner(title: str, cs_name: str, port: int, **info: str) -> None:
 
 def _launch_server(gh: GitHubManager, cs_name: str, port: int,
                    script: str, script_name: str,
-                   banner_fn) -> None:
+                   banner_fn, domain: str = None,
+                   config: 'Config' = None) -> None:
     """
     Upload a server script, start it, forward the port, show banner, and tail logs.
 
     This is the shared orchestrator for all serve_* functions. It handles:
     upload script -> start server -> verify -> port forward -> banner -> tail logs.
+
+    If a domain is specified, deploys a Cloudflare Worker as a reverse proxy
+    (auto-deploy with credentials, or generates the script for manual setup).
 
     Args:
         gh: GitHub manager
@@ -367,7 +371,9 @@ def _launch_server(gh: GitHubManager, cs_name: str, port: int,
         port: Port to serve on
         script: Formatted Python script content to upload
         script_name: Remote filename (e.g., 'server.py', 'redirect_server.py')
-        banner_fn: Callable(cs_name, port) that prints the server info banner
+        banner_fn: Callable(cs_name, port, domain=None) that prints the server info banner
+        domain: Optional custom domain for Cloudflare Worker proxy
+        config: Configuration (required if domain is set)
     """
     logger = get_logger()
 
@@ -382,12 +388,21 @@ def _launch_server(gh: GitHubManager, cs_name: str, port: int,
 
     fwd = _start_port_forwarding(gh, cs_name, port)
 
-    banner_fn(cs_name, port)
+    # Deploy Cloudflare Worker if domain is specified
+    cf_worker = None
+    if domain and config:
+        from .cloudflare import setup_worker
+        codespace_url = f"{cs_name}-{port}.app.github.dev"
+        cf_worker = setup_worker(codespace_url, domain, config)
+
+    banner_fn(cs_name, port, domain=domain)
 
     try:
         _tail_remote_logs(gh, cs_name)
     finally:
         fwd.terminate()
+        if cf_worker:
+            cf_worker.teardown()
 
 
 # =============================================================================
@@ -397,7 +412,8 @@ def _launch_server(gh: GitHubManager, cs_name: str, port: int,
 # =============================================================================
 
 
-def serve_file(file_path: Path, port: int, gh: GitHubManager, config: Config = None) -> None:
+def serve_file(file_path: Path, port: int, gh: GitHubManager,
+               config: Config = None, domain: str = None) -> None:
     """
     Upload a single file to a Codespace and serve it via HTTP.
 
@@ -417,12 +433,14 @@ def serve_file(file_path: Path, port: int, gh: GitHubManager, config: Config = N
     logger.info(f"Uploading {file_path.name}...")
     _upload_file(gh, cs_name, file_path, f"{SERVE_DIR}/{file_path.name}")
 
-    def banner(cs, p):
+    def banner(cs, p, domain=None):
         file_url = f"https://{cs}-{p}.app.github.dev/{file_path.name}"
         print(f"\n{'=' * 60}")
         print("File is now being served!")
         print(f"{'=' * 60}\n")
         print(f"File URL:\n  {file_url}\n")
+        if domain:
+            print(f"Custom domain:\n  https://{domain}/{file_path.name}\n")
         print(f"curl command:\n  curl -L \"{file_url}\"\n")
         print(f"wget command:\n  wget \"{file_url}\"\n")
         print(f"Local access:\n  curl http://localhost:{p}/{file_path.name}\n")
@@ -431,10 +449,11 @@ def serve_file(file_path: Path, port: int, gh: GitHubManager, config: Config = N
     _launch_server(gh, cs_name, port,
                    script=_FILE_SERVER_SCRIPT.format(PORT=port),
                    script_name="server.py",
-                   banner_fn=banner)
+                   banner_fn=banner, domain=domain, config=config)
 
 
-def serve_directory(dir_path: Path, port: int, gh: GitHubManager, config: Config = None) -> None:
+def serve_directory(dir_path: Path, port: int, gh: GitHubManager,
+                    config: Config = None, domain: str = None) -> None:
     """
     Upload a directory to a Codespace and serve it via HTTP.
 
@@ -459,12 +478,14 @@ def serve_directory(dir_path: Path, port: int, gh: GitHubManager, config: Config
     for f in files:
         _upload_file(gh, cs_name, f, f"{SERVE_DIR}/{f.name}")
 
-    def banner(cs, p):
+    def banner(cs, p, domain=None):
         base_url = f"https://{cs}-{p}.app.github.dev/"
         print(f"\n{'=' * 60}")
         print("Directory is now being served!")
         print(f"{'=' * 60}\n")
         print(f"Base URL:\n  {base_url}\n")
+        if domain:
+            print(f"Custom domain:\n  https://{domain}/\n")
         print("Files available:")
         for f in files:
             print(f"  {base_url}{f.name}")
@@ -473,11 +494,12 @@ def serve_directory(dir_path: Path, port: int, gh: GitHubManager, config: Config
     _launch_server(gh, cs_name, port,
                    script=_FILE_SERVER_SCRIPT.format(PORT=port),
                    script_name="server.py",
-                   banner_fn=banner)
+                   banner_fn=banner, domain=domain, config=config)
 
 
 def serve_redirect(target_url: str, port: int, redirect_code: int,
-                   gh: GitHubManager, config: Config = None) -> None:
+                   gh: GitHubManager, config: Config = None,
+                   domain: str = None) -> None:
     """
     Start an HTTP redirect server in a Codespace.
 
@@ -494,12 +516,14 @@ def serve_redirect(target_url: str, port: int, redirect_code: int,
 
     _setup_server_environment(gh, cs_name, port)
 
-    def banner(cs, p):
+    def banner(cs, p, domain=None):
         url = f"https://{cs}-{p}.app.github.dev/"
         print(f"\n{'=' * 60}")
         print("Redirect server is running!")
         print(f"{'=' * 60}\n")
         print(f"Redirect URL:\n  {url}\n")
+        if domain:
+            print(f"Custom domain:\n  https://{domain}/\n")
         print(f"Target:\n  {target_url}\n")
         print(f"Redirect Type:\n  HTTP {redirect_code}\n")
         print(f"Local access:\n  curl -v http://localhost:{p}/\n")
@@ -513,11 +537,12 @@ def serve_redirect(target_url: str, port: int, redirect_code: int,
                        REDIRECT_CODE=redirect_code,
                        PORT=port),
                    script_name="redirect_server.py",
-                   banner_fn=banner)
+                   banner_fn=banner, domain=domain, config=config)
 
 
 def serve_custom(port: int, response_body: str, content_type: str,
-                 status_code: int, gh: GitHubManager, config: Config = None) -> None:
+                 status_code: int, gh: GitHubManager, config: Config = None,
+                 domain: str = None) -> None:
     """
     Start a custom HTTP response server in a Codespace.
 
@@ -534,12 +559,14 @@ def serve_custom(port: int, response_body: str, content_type: str,
 
     _setup_server_environment(gh, cs_name, port)
 
-    def banner(cs, p):
+    def banner(cs, p, domain=None):
         url = f"https://{cs}-{p}.app.github.dev/"
         print(f"\n{'=' * 60}")
         print("Custom response server is running!")
         print(f"{'=' * 60}\n")
         print(f"URL:          {url}")
+        if domain:
+            print(f"Custom:       https://{domain}/")
         print(f"Local:        http://localhost:{p}/")
         print(f"Status:       {status_code}")
         print(f"Content-Type: {content_type}")
@@ -553,10 +580,11 @@ def serve_custom(port: int, response_body: str, content_type: str,
                        STATUS_CODE=status_code,
                        PORT=port),
                    script_name="custom_server.py",
-                   banner_fn=banner)
+                   banner_fn=banner, domain=domain, config=config)
 
 
-def serve_capture(port: int, gh: GitHubManager, config: Config = None) -> None:
+def serve_capture(port: int, gh: GitHubManager, config: Config = None,
+                  domain: str = None) -> None:
     """
     Start a capture server that logs and saves all incoming POST data.
 
@@ -568,6 +596,7 @@ def serve_capture(port: int, gh: GitHubManager, config: Config = None) -> None:
         port: Port to listen on
         gh: GitHub manager
         config: Configuration (for codespace selection)
+        domain: Optional custom domain via Cloudflare Worker
     """
     logger = get_logger()
 
@@ -579,18 +608,21 @@ def serve_capture(port: int, gh: GitHubManager, config: Config = None) -> None:
     _setup_server_environment(gh, cs_name, port)
     _ssh(gh, cs_name, "mkdir -p /tmp/serve/captures")
 
-    def banner(cs, p):
+    def banner(cs, p, domain=None):
         url = f"https://{cs}-{p}.app.github.dev/"
         sep = "=" * 60
         print(f"\n{sep}")
         print("Capture server is running!")
         print(f"{sep}\n")
         print(f"Capture URL:\n  {url}\n")
+        if domain:
+            print(f"Custom domain:\n  https://{domain}/\n")
         print(f"Local:        http://localhost:{p}/\n")
+        send_url = f"https://{domain}/" if domain else url
         print("Send data with:")
-        print(f"  curl -X POST -d 'data here' {url}")
-        print(f"  curl -X POST --data-binary @file.bin {url}")
-        print(f"  echo -n 'SGVsbG8=' | curl -X POST -d @- {url}\n")
+        print(f"  curl -X POST -d 'data here' {send_url}")
+        print(f"  curl -X POST --data-binary @file.bin {send_url}")
+        print(f"  echo -n 'SGVsbG8=' | curl -X POST -d @- {send_url}\n")
         print("Base64 payloads are auto-detected and decoded.")
         print("Captures saved to /tmp/serve/captures/ on Codespace.")
         print("On Ctrl+C, all captures will be downloaded locally.\n")
@@ -599,7 +631,7 @@ def serve_capture(port: int, gh: GitHubManager, config: Config = None) -> None:
     _launch_server(gh, cs_name, port,
                    script=_CAPTURE_SERVER_SCRIPT.format(PORT=port),
                    script_name="capture_server.py",
-                   banner_fn=banner)
+                   banner_fn=banner, domain=domain, config=config)
 
     _download_captures(gh, cs_name)
 
@@ -629,6 +661,10 @@ def stop_server(port: int, gh: GitHubManager, config: Config = None) -> None:
         )
     except FileNotFoundError:
         pass
+
+    # Tear down Cloudflare Worker if credentials are configured
+    from .cloudflare import teardown_worker
+    teardown_worker(port, config)
 
     logger.info("Server stopped")
 
@@ -662,6 +698,11 @@ def clean_all(gh: GitHubManager, config: Config = None) -> None:
         subprocess.run(['pkill', '-f', 'gh codespace ports forward'], capture_output=True)
     except FileNotFoundError:
         pass
+
+    # Tear down any Cloudflare Workers for common ports
+    from .cloudflare import teardown_worker
+    for port in [9999, 8080, 8888]:
+        teardown_worker(port, config)
 
     logger.info("Checking remaining forwarded ports...")
     result = gh.run_gh_command(
@@ -705,7 +746,8 @@ def cmd_file(args, config: Config, gh: GitHubManager) -> int:
         file_path=Path(args.filepath),
         port=args.port,
         gh=gh,
-        config=config
+        config=config,
+        domain=getattr(args, 'domain', None)
     )
     return 0
 
@@ -716,7 +758,8 @@ def cmd_dir(args, config: Config, gh: GitHubManager) -> int:
         dir_path=Path(args.directory),
         port=args.port,
         gh=gh,
-        config=config
+        config=config,
+        domain=getattr(args, 'domain', None)
     )
     return 0
 
@@ -728,7 +771,8 @@ def cmd_redirect(args, config: Config, gh: GitHubManager) -> int:
         port=args.port,
         redirect_code=args.code,
         gh=gh,
-        config=config
+        config=config,
+        domain=getattr(args, 'domain', None)
     )
     return 0
 
@@ -741,7 +785,8 @@ def cmd_custom(args, config: Config, gh: GitHubManager) -> int:
         content_type=args.content_type,
         status_code=args.status,
         gh=gh,
-        config=config
+        config=config,
+        domain=getattr(args, 'domain', None)
     )
     return 0
 
@@ -751,7 +796,8 @@ def cmd_capture(args, config: Config, gh: GitHubManager) -> int:
     serve_capture(
         port=args.port,
         gh=gh,
-        config=config
+        config=config,
+        domain=getattr(args, 'domain', None)
     )
     return 0
 
@@ -798,6 +844,7 @@ COMMANDS:
 
 OPTIONS:
     -c, --codespace    Codespace name to use (default: auto-select)
+    -d, --domain       Custom domain via Cloudflare Worker reverse proxy
     -v, --verbose      Enable verbose output
 
 EXAMPLES:
@@ -828,6 +875,10 @@ EXAMPLES:
     cs-serve capture
     cs-serve capture 8080
 
+    # Custom domain via Cloudflare Worker
+    cs-serve -d dev.example.com file payload.bin
+    cs-serve -d dev.example.com capture
+
     # Stop the server
     cs-serve stop
 
@@ -847,6 +898,12 @@ USE CASES:
     - Data capture: Log and save POST data with base64 auto-decode
     - Exfiltration: Capture data via request logging
     - Payload hosting: Serve exploit files
+
+CUSTOM DOMAIN:
+    Use -d/--domain to proxy through a Cloudflare Worker on your own domain.
+    Set CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID env vars for auto-deploy.
+    Without credentials, a worker script is generated for manual deployment.
+    The worker is automatically torn down on Ctrl+C.
 
 NOTES:
     - Directory listing is disabled for file/dir serving

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -45,6 +45,10 @@ class Config:
         # Advanced settings
         'dns_proxy': False,
         'verbose': False,
+
+        # Cloudflare Worker settings
+        'cloudflare_api_token': '',
+        'cloudflare_account_id': '',
     }
 
     def __init__(self, config_dir: Optional[Path] = None, config_file: Optional[Path] = None):
@@ -89,6 +93,8 @@ class Config:
             'DNS_PROXY': ('dns_proxy', lambda x: x.lower() in ('true', '1', 'yes')),
             'VERBOSE': ('verbose', lambda x: x.lower() in ('true', '1', 'yes')),
             'NUM_PROXIES': ('num_proxies', int),
+            'CLOUDFLARE_API_TOKEN': ('cloudflare_api_token', str),
+            'CLOUDFLARE_ACCOUNT_ID': ('cloudflare_account_id', str),
         }
 
         for env_var, (config_key, converter) in env_mappings.items():

--- a/docs/use-cases/file-hosting.md
+++ b/docs/use-cases/file-hosting.md
@@ -95,6 +95,21 @@ cs-serve capture
 # Press Ctrl+C to stop and download all captures locally
 ```
 
+## Custom Domain via Cloudflare
+
+Proxy through a Cloudflare Worker to serve content on your own domain:
+
+```bash
+# Auto-deploy (with CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID set)
+cs-serve -d dev.example.com file payload.bin
+cs-serve -d dev.example.com capture
+
+# Without credentials, generates worker.js for manual deployment
+cs-serve -d dev.example.com redirect http://internal:8080/
+```
+
+The worker is automatically torn down when you press `Ctrl+C`.
+
 ## Real-Time Logging
 
 All servers log incoming requests to stdout in real time. This is useful for:

--- a/docs/user-guide/command-reference/cs-serve.md
+++ b/docs/user-guide/command-reference/cs-serve.md
@@ -147,7 +147,34 @@ cs-serve list
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-c`, `--codespace` | Codespace name | auto-select |
+| `-d`, `--domain` | Custom domain via Cloudflare Worker | none |
 | `-v`, `--verbose` | Verbose output | off |
+
+## Custom Domain via Cloudflare Worker
+
+Use the `-d` flag to proxy traffic through a Cloudflare Worker on your own domain, making served content accessible via a clean URL instead of the `*.app.github.dev` URL.
+
+```bash
+cs-serve -d dev.example.com file payload.bin
+cs-serve -d dev.example.com capture
+cs-serve -d dev.example.com redirect http://internal:8080/
+```
+
+### Auto-deploy mode
+
+Set `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables. The worker is deployed automatically and torn down on `Ctrl+C`.
+
+```bash
+export CLOUDFLARE_API_TOKEN="your-api-token"
+export CLOUDFLARE_ACCOUNT_ID="your-account-id"
+cs-serve -d dev.example.com file payload.bin
+# → Worker deployed, both URLs shown
+# → Ctrl+C tears down worker automatically
+```
+
+### Manual mode
+
+Without credentials, cs-serve generates a `worker.js` file and prints setup instructions for the Cloudflare dashboard.
 
 ## How It Works
 


### PR DESCRIPTION
Adds -d/--domain flag to all cs-serve commands to proxy traffic through a Cloudflare Worker on a custom domain. Auto-deploys the worker when CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are set, otherwise generates a worker.js script for manual deployment. Workers are automatically torn down on Ctrl+C, stop, and clean commands.