### PR TITLE
Phase 2-3: UX improvements, hardening, security fixes, docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest -q --tb=short

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/python-3.8+-blue.svg" alt="Python 3.8+">
+  <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+">
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" alt="Apache 2.0 License"></a>
   <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black"></a>
 </p>
@@ -22,8 +22,8 @@
 > **GitHub's Terms of Service** and **Acceptable Use Policies** explicitly prohibit certain uses of Codespaces, including:
 > 
 > - Using Codespaces to disrupt services, gain unauthorized access to networks/devices, or support attack infrastructure (see [GitHub Terms for Additional Products and Features - Codespaces section](https://docs.github.com/en/site-policy/github-terms/github-terms-for-additional-products-and-features#codespaces)).
-> - Placing disproportionate burden on GitHub's servers (e.g., excessive bandwidth, proxy/CDN-like usage).
-> - Any activity violating applicable laws, third-party rights, or GitHub's Acceptable Use Policies (e.g., unauthorized scanning, proxying for malicious purposes).
+> - Placing disproportionate burden on GitHub's servers (e.g. excessive bandwidth, proxy/CDN-like usage).
+> - Any activity violating applicable laws, third-party rights, or GitHub's Acceptable Use Policies (e.g. unauthorized scanning, proxying for malicious purposes).
 > 
 > Misuse may result in suspension/termination of your GitHub account, Codespaces access restrictions, or other enforcement actions by GitHub.
 > The author is not liable for any harm or damage resulting from its unauthorized use.
@@ -38,10 +38,10 @@ Full documentation at **[https://dstours.github.io/fluffy-barnacle/](https://dst
 
 | Tool | Description |
 |------|-------------|
-| **cs-proxy** | SOCKS5 and HTTP proxy via SSH tunnel with auto-reconnect and Burp Suite integration |
+| **cs-proxy** | SOCKS5 and HTTP proxy via SSH tunnel with auto-reconnect, circuit breaker, and Burp Suite integration |
 | **cs-serve** | Instant public HTTPS file hosting, redirect servers, custom HTTP responses, and data capture via `*.app.github.dev` |
 | **cs-wg** | Full WireGuard VPN tunnel with route management and traffic monitoring |
-| **cs-tools** | Drop-in wrappers for nmap, ffuf, httpx, nuclei, sqlmap with automatic SOCKS5 proxy arguments |
+| **cs-tools** | Drop-in wrappers for nmap, ffuf, httpx, nuclei, sqlmap with automatic SOCKS5 proxy arguments and smart tunnel rotation |
 
 Codespace IPs rotate on each creation, giving you fresh egress IPs on demand. Each tool works from the CLI or as a Python library.
 
@@ -50,15 +50,16 @@ Codespace IPs rotate on each creation, giving you fresh egress IPs on demand. Ea
 ```bash
 pip install -e .
 gh auth login
+cs-proxy check               # verify your setup
 cs-proxy start
-cs-tools ipcheck          # verify you're proxied
+cs-tools ipcheck             # verify you're proxied
 ```
 
 See the [Quick Start Guide](https://dstours.github.io/fluffy-barnacle/quickstart/) for detailed setup.
 
 ## Feature Highlights
 
-### SOCKS5 Proxy with Auto-Reconnect
+### SOCKS5 Proxy with Auto-Reconnect & Circuit Breaker
 
 ```bash
 cs-proxy start                                # single proxy, auto-select codespace
@@ -67,9 +68,12 @@ cs-proxy create                               # create a new codespace and track
 cs-proxy start                                # picks up unstarted tracked codespaces
 cs-proxy -n 2 start -l WestEurope -l EastUs  # two proxies, different regions (ports 1080 + 1081)
 cs-proxy status             # codespace state + per-tunnel exit IP
+cs-proxy status --watch     # auto-refresh every 2 seconds
 cs-proxy ssh                # interactive shell (menu if multiple codespaces tracked)
 cs-proxy env                # export statements for tools that read env vars
 cs-proxy burp               # upstream proxy config for Burp Suite
+cs-proxy pac                # generate Proxy Auto-Config (PAC) file
+cs-proxy check              # diagnose setup, auth, ports, and state health
 ```
 
 **Adding a second proxy:**
@@ -78,6 +82,24 @@ There are two workflows for running multiple exit IPs:
 
 1. **Auto-add:** Run `cs-proxy start` again when a proxy is already running — it creates a new codespace and starts a second tunnel automatically.
 2. **Manual:** Run `cs-proxy create` to create a codespace first, then `cs-proxy start` to tunnel it (skips the first running tunnel and starts one for the new codespace).
+
+**Dry-run mode:**
+
+```bash
+cs-proxy --dry-run start    # show what would happen without making changes
+cs-proxy --dry-run stop     # show what would stop without stopping anything
+```
+
+**Shell completion:**
+
+```bash
+cs-proxy completion bash > ~/.config/cs-proxy/completion.bash
+source ~/.config/cs-proxy/completion.bash
+```
+
+### Smart Proxy Rotation
+
+`cs-tools` automatically picks a healthy tunnel from `state.json`. If you have multiple tunnels running, tool traffic is rotated across them without manual port selection.
 
 ### Public File Hosting
 
@@ -111,7 +133,7 @@ cs-tools pcs gobuster dir -u https://target.com -w list.txt
 
 ## Installation
 
-**Requirements:** Python 3.8+, [GitHub CLI](https://cli.github.com/) (`gh`), `ssh`, `curl`
+**Requirements:** Python 3.10+, [GitHub CLI](https://cli.github.com/) (`gh`), `ssh`, `curl`
 
 ```bash
 git clone https://github.com/dstours/fluffy-barnacle.git
@@ -152,15 +174,25 @@ Config file: `~/.config/cs-proxy/config.yaml`
 ```yaml
 socks_port: 1080
 http_proxy_port: 8080
-num_proxies: 1              # 1-2; starts a tunnel through each on consecutive ports
+num_proxies: 1              # 1-5; starts a tunnel through each on consecutive ports
 codespace_name: ""
 locations: []               # e.g. [WestEurope, EastUs] — one region per codespace
 reconnect_delay: 5
 max_reconnect_delay: 300
 verbose: false
+
+# Profiles let you switch between preset configurations
+profile: ""
+profiles:
+  redteam:
+    num_proxies: 2
+    locations: [WestEurope, EastUs]
+  stealth:
+    dns_proxy: true
+    verbose: true
 ```
 
-See the [Configuration Reference](https://dstours.github.io/fluffy-barnacle/user-guide/configuration/) for all options and environment variables.
+See the [Configuration Reference](https://dstours.github.io/fluffy-barnacle/user-guide/configuration/) for all options, environment variables, and profiles.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Config file: `~/.config/cs-proxy/config.yaml`
 ```yaml
 socks_port: 1080
 http_proxy_port: 8080
-num_proxies: 1              # 1-5; starts a tunnel through each on consecutive ports
+num_proxies: 1              # 1-2 on free tier; each gets its own tunnel on consecutive ports
 codespace_name: ""
 locations: []               # e.g. [WestEurope, EastUs] — one region per codespace
 reconnect_delay: 5

--- a/csproxy/__init__.py
+++ b/csproxy/__init__.py
@@ -13,6 +13,7 @@ __license__ = "MIT"
 from .github import GitHubManager
 from .codespace import CodespaceSelector
 from .proxy import ProxychainsConfig
+from .state import State
 from .tunnel import HTTPProxyManager, SSHTunnel
 from .tools import (
     check_proxy,
@@ -44,6 +45,7 @@ __all__ = [
     'HTTPProxyManager',
     'CodespaceSelector',
     'ProxychainsConfig',
+    'State',
     # Proxied tool wrappers
     'check_proxy',
     'ipcheck',

--- a/csproxy/_worker.py
+++ b/csproxy/_worker.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+Internal reconnect worker for SSH tunnels.
+
+Launched as a detached subprocess by SSHTunnel. Reads a JSON spec file
+(path passed as argv[1]) and runs the gh codespace ssh reconnect loop.
+Exits gracefully on SIGTERM/SIGINT or when the stop file is touched.
+
+Debug mode:
+    python -m csproxy._worker /path/to/spec.json --debug
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("spec_path", help="Path to JSON worker spec file")
+    parser.add_argument("--debug", action="store_true", help="Print debug output to stderr")
+    args = parser.parse_args()
+
+    spec_path = Path(args.spec_path)
+    debug = args.debug
+
+    if not spec_path.exists():
+        print(f"Worker spec not found: {spec_path}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        spec = json.loads(spec_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Failed to read worker spec: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    log_file = Path(spec["log_file"])
+    stop_file = Path(spec["stop_file"])
+    reconnect_delay = spec.get("reconnect_delay", 5)
+    max_reconnect_delay = spec.get("max_reconnect_delay", 300)
+    gh_cmd = spec["gh_cmd"]
+
+    stop_requested = False
+
+    def _on_signal(signum: int, frame) -> None:
+        nonlocal stop_requested
+        if debug:
+            print(f"[worker] Received signal {signum}, setting stop flag", file=sys.stderr)
+        stop_requested = True
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    delay = reconnect_delay
+    attempt = 0
+    while not stop_requested:
+        if stop_file.exists():
+            if debug:
+                print("[worker] Stop file detected, exiting", file=sys.stderr)
+            stop_file.unlink(missing_ok=True)
+            break
+
+        attempt += 1
+        if debug:
+            print(f"[worker] Attempt {attempt}: running gh ssh (delay={delay}s)", file=sys.stderr)
+
+        log_mode = "a" if log_file.exists() else "w"
+        try:
+            with open(log_file, log_mode) as log_fd:
+                subprocess.run(gh_cmd, stdout=log_fd, stderr=log_fd, timeout=60)
+        except subprocess.TimeoutExpired:
+            if debug:
+                print("[worker] SSH command timed out, reconnecting...", file=sys.stderr)
+        except OSError as e:
+            # Log file may have become unavailable (e.g. config dir deleted)
+            print(f"[worker] Log file error: {e}", file=sys.stderr)
+            time.sleep(delay)
+            delay = min(delay * 2, max_reconnect_delay)
+            continue
+
+        if stop_file.exists():
+            stop_file.unlink(missing_ok=True)
+            break
+
+        if stop_requested:
+            break
+
+        time.sleep(delay)
+        delay = min(delay * 2, max_reconnect_delay)
+
+    if debug:
+        print("[worker] Exiting cleanly", file=sys.stderr)
+
+    # Clean up spec file to indicate worker exited
+    spec_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/csproxy/_worker.py
+++ b/csproxy/_worker.py
@@ -14,6 +14,7 @@ Debug mode:
 import argparse
 import json
 import os
+import random
 import signal
 import subprocess
 import sys
@@ -91,7 +92,10 @@ def main() -> None:
         if stop_requested:
             break
 
-        time.sleep(delay)
+        # Add jitter (±25%) to prevent thunder-herding when multiple tunnels
+        # reconnect simultaneously after a GitHub SSH endpoint blip.
+        jittered = delay * (1 + random.uniform(-0.25, 0.25))
+        time.sleep(max(0.5, jittered))
         delay = min(delay * 2, max_reconnect_delay)
 
     if debug:

--- a/csproxy/cli.py
+++ b/csproxy/cli.py
@@ -39,6 +39,8 @@ def main_proxy(argv=None):
                         help='Region for new Codespace: EastUs, WestUs2, WestEurope, SouthEastAsia'
                              ' (repeat for multiple: -l WestEurope -l EastUs)')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would happen without making changes')
     parser.add_argument('-h', '--help', action='store_true', help='Show help and exit')
     parser.add_argument('command', nargs='?', default='help', help='Command to run')
     parser.add_argument('command_args', nargs='*', help='Command arguments')
@@ -76,6 +78,8 @@ def main_proxy(argv=None):
         config.set('locations', parsed.locations)
     if parsed.verbose:
         config.set('verbose', True)
+
+    config._dry_run = parsed.dry_run
 
     gh = GitHubManager(config_dir=config.config_dir)
 

--- a/csproxy/cli.py
+++ b/csproxy/cli.py
@@ -55,6 +55,18 @@ def main_proxy(argv=None):
     config = Config()
     config.ensure_dirs()
 
+    # Reconcile state: detect crashed tunnels from previous runs
+    from .state import State
+    try:
+        state = State(config.config_dir)
+        crashed = state.reconcile()
+        if crashed:
+            logger.warning(f"Detected {len(crashed)} crashed tunnel(s): "
+                           + ", ".join(str(t['port']) for t in crashed))
+    except TimeoutError as e:
+        logger.error(f"State file is locked by another process: {e}")
+        return 1
+
     if parsed.port:
         config.set('socks_port', parsed.port)
     config.set('num_proxies', parsed.num_proxies)

--- a/csproxy/completion.py
+++ b/csproxy/completion.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Shell completion script generator for cs-proxy.
+
+Supports bash and zsh. Generated scripts are pure text with no runtime
+dependencies — users source them in their shell rc file.
+"""
+
+BASH_COMPLETION = """#!/bin/bash
+# cs-proxy bash completion
+_cs_proxy_completion() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local opts="start stop restart status list create set http proxychains env burp keygen config logs split ssh run name teardown down delete rm token aliases completion pac help"
+    COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+}
+complete -F _cs_proxy_completion cs-proxy
+"""
+
+ZSH_COMPLETION = """#compdef cs-proxy
+local -a subcmds
+subcmds=(
+    'start:Start the SOCKS5 proxy tunnel'
+    'stop:Stop the proxy tunnel'
+    'restart:Restart the proxy tunnel'
+    'status:Show proxy and Codespace status'
+    'list:List available Codespaces'
+    'create:Create a new Codespace'
+    'set:Set the default Codespace'
+    'http:Start HTTP proxy'
+    'proxychains:Generate proxychains configuration'
+    'env:Show environment variable exports'
+    'burp:Show Burp Suite configuration'
+    'keygen:Generate SSH key'
+    'config:Edit configuration'
+    'logs:Show proxy logs'
+    'split:Set up split tunneling'
+    'ssh:Open SSH session in Codespace'
+    'run:Run a command in Codespace'
+    'name:Print current Codespace name'
+    'teardown:Stop proxy and Codespace'
+    'down:Alias for teardown'
+    'delete:Delete Codespace'
+    'rm:Alias for delete'
+    'token:Set GitHub token'
+    'aliases:Write shell aliases'
+    'completion:Generate shell completion script'
+    'pac:Generate Proxy Auto-Config'
+    'help:Show help'
+)
+_describe 'command' subcmds
+"""
+
+
+def generate_completion(shell: str) -> str:
+    """
+    Generate a shell completion script.
+
+    Args:
+        shell: 'bash' or 'zsh'
+
+    Returns:
+        Completion script as a string.
+    """
+    shell = shell.lower().strip()
+    if shell == "bash":
+        return BASH_COMPLETION
+    if shell in ("zsh",):
+        return ZSH_COMPLETION
+    return f"# Unsupported shell: {shell}. Supported: bash, zsh\n"

--- a/csproxy/display.py
+++ b/csproxy/display.py
@@ -77,11 +77,19 @@ Your browser connects to Burp normally, and Burp routes through SOCKS.
 """)
 
 
-def show_status(config: Config, gh) -> None:
-    """Display proxy and Codespace status information."""
+def _show_status_body(config: Config, gh) -> None:
+    """Core status display logic shared by show_status and watch_status."""
+    from .state import State
     from .tunnel import SSHTunnel
 
     logger = get_logger()
+    try:
+        state = State(config.config_dir)
+        state.reconcile()
+    except TimeoutError as e:
+        print(f"Error: State file is locked by another process: {e}")
+        return
+
     print("\n=== cs-proxy Status ===\n")
 
     pid_file = config.config_dir / 'proxy.pid'
@@ -97,6 +105,16 @@ def show_status(config: Config, gh) -> None:
             print("Proxy Status:    STOPPED (stale PID file)")
     else:
         print("Proxy Status:    STOPPED")
+
+    # Show state.json tunnels
+    state_tunnels = state.get_tunnels(kind='ssh')
+    if state_tunnels:
+        print("\nManaged tunnels:")
+        for t in state_tunnels:
+            status = t.get('status', 'unknown')
+            port = t.get('port', '?')
+            cs = t.get('codespace_name', '?') or '?'
+            print(f"  :{port}  {status:<10}  {cs}")
 
     all_names = config.codespace_names or ([config.codespace_name] if config.codespace_name else [])
     num_tunnels = len(all_names)
@@ -115,12 +133,12 @@ def show_status(config: Config, gh) -> None:
             tunnel = SSHTunnel(config, config.codespace_name)
             if tunnel.health_check():
                 exit_ip = tunnel.get_exit_ip()
-                print(f"Proxy Health:    HEALTHY")
+                print(f"\nProxy Health:    HEALTHY")
                 print(f"Proxied IP:      {exit_ip or 'unknown'}")
             else:
-                print(f"Proxy Health:    UNHEALTHY")
+                print(f"\nProxy Health:    UNHEALTHY")
 
-    print(f"SOCKS5 Port:     {config.socks_port}")
+    print(f"\nSOCKS5 Port:     {config.socks_port}")
     print(f"HTTP Port:       {config.http_proxy_port}")
 
     # Show all codespaces
@@ -136,7 +154,7 @@ def show_status(config: Config, gh) -> None:
         print(f"\nCodespaces:")
         for cs in codespaces:
             name = cs.get('name', '')
-            state = cs.get('state', 'unknown')
+            cs_state = cs.get('state', 'unknown')
             repo = cs.get('repository', '')
             if name in managed:
                 idx = config.codespace_names.index(name) if name in config.codespace_names else -1
@@ -145,7 +163,7 @@ def show_status(config: Config, gh) -> None:
                 role = " [active]"
             else:
                 role = ""
-            print(f"  {name:<45} {state:<12}  {repo}{role}")
+            print(f"  {name:<45} {cs_state:<12}  {repo}{role}")
     elif active:
         print(f"\nCodespace:       {active}")
 
@@ -157,6 +175,25 @@ def show_status(config: Config, gh) -> None:
     )
     local_ip = result.stdout.strip() if result.returncode == 0 else 'unknown'
     print(f"\nYour Direct IP:  {local_ip}")
+    print()
+
+
+def show_status(config: Config, gh) -> None:
+    """Display proxy and Codespace status information."""
+    _show_status_body(config, gh)
+
+
+def watch_status(config: Config, gh, interval: int = 2) -> None:
+    """Auto-refresh status display every N seconds until Ctrl+C."""
+    import sys, time
+    try:
+        while True:
+            sys.stdout.write("\033[2J\033[H")
+            sys.stdout.flush()
+            _show_status_body(config, gh)
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        pass
     print()
 
 

--- a/csproxy/display.py
+++ b/csproxy/display.py
@@ -229,7 +229,8 @@ COMMANDS:
     run <cmd>       Run a command in the Codespace
     name            Print the current Codespace name
 
-    down            Stop proxy and Codespace (saves storage, no compute)
+    teardown        Stop proxy and Codespace (saves storage, no compute)
+    down            Stop proxy and permanently delete Codespace(s)
     delete          Permanently delete the Codespace
 
     list            List available Codespaces

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -315,7 +315,11 @@ def cmd_restart(args, config: Config, gh: GitHubManager) -> int:
 
 
 def cmd_status(args, config: Config, gh: GitHubManager) -> int:
-    """Show proxy status."""
+    """Show proxy status. Pass --watch or -w for auto-refresh."""
+    if args and ('--watch' in args or '-w' in args):
+        from .display import watch_status
+        watch_status(config, gh)
+        return 0
     show_status(config, gh)
     return 0
 
@@ -634,6 +638,35 @@ alias cs-wg='sudo env "PATH=$PATH" cs-wg'
     return 0
 
 
+def cmd_pac(args, config: Config, gh: GitHubManager) -> int:
+    """Generate Proxy Auto-Config (PAC) file contents."""
+    pac = f"""function FindProxyForURL(url, host) {{
+    if (isPlainHostName(host) ||
+        shExpMatch(host, "*.local") ||
+        isInNet(host, "127.0.0.0", "255.0.0.0") ||
+        isInNet(host, "10.0.0.0", "255.0.0.0") ||
+        isInNet(host, "172.16.0.0", "255.240.0.0") ||
+        isInNet(host, "192.168.0.0", "255.255.0.0")) {{
+        return "DIRECT";
+    }}
+    return "SOCKS5 127.0.0.1:{config.socks_port}; DIRECT";
+}}"""
+    print(pac)
+    return 0
+
+
+def cmd_completion(args, config: Config, gh: GitHubManager) -> int:
+    """Generate shell completion script."""
+    shell = args[0] if args else 'bash'
+    from .completion import generate_completion
+    script = generate_completion(shell)
+    if "Unsupported shell" in script:
+        get_logger().error(f"Unsupported shell: {shell}. Supported: bash, zsh")
+        return 1
+    print(script)
+    return 0
+
+
 def cmd_help(args, config: Config, gh: GitHubManager) -> int:
     """Show help."""
     show_help()
@@ -670,5 +703,7 @@ COMMANDS = {
     'rm':           cmd_delete,     # Alias
     'token':        cmd_token,
     'aliases':      cmd_aliases,
+    'pac':          cmd_pac,
+    'completion':   cmd_completion,
     'help':         cmd_help,
 }

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 from .github import GitHubManager
+from .state import State
 from .utils import (
     Config,
     GitHubAuthError,
@@ -547,8 +548,21 @@ def cmd_teardown(args, config: Config, gh: GitHubManager) -> int:
     check_dependencies(['gh'])
     gh.check_auth()
 
-    tunnel = SSHTunnel(config, config.codespace_name or '')
-    tunnel.stop()
+    # Clean up every tunnel in state, not just config-tracked ones
+    state = State(config.config_dir)
+    tunnels = state.get_tunnels(kind='ssh')
+    for t in tunnels:
+        port = t.get('port', config.socks_port)
+        cs_name = t.get('codespace_name', '')
+        tunnel = SSHTunnel(config, cs_name, port=port)
+        tunnel.cleanup()
+        logger.info(f"Stopped tunnel :{port}")
+
+    # Also clean up any orphaned artifacts in workers/ directory
+    workers_dir = config.config_dir / 'workers'
+    if workers_dir.exists():
+        for f in workers_dir.iterdir():
+            f.unlink(missing_ok=True)
 
     all_names = config.codespace_names or ([config.codespace_name] if config.codespace_name else [])
     if all_names:
@@ -570,11 +584,21 @@ def cmd_down(args, config: Config, gh: GitHubManager) -> int:
     check_dependencies(['gh'])
     gh.check_auth()
 
-    # Step 1: stop tunnels
-    tunnel = SSHTunnel(config, config.codespace_name or '')
-    tunnel.stop()
-    for i in range(1, len(config.codespace_names)):
-        SSHTunnel(config, '', port=config.socks_port + i, pid_suffix=str(i + 1)).stop()
+    # Step 1: aggressive cleanup of every tunnel in state
+    state = State(config.config_dir)
+    tunnels = state.get_tunnels(kind='ssh')
+    for t in tunnels:
+        port = t.get('port', config.socks_port)
+        cs_name = t.get('codespace_name', '')
+        tunnel = SSHTunnel(config, cs_name, port=port)
+        tunnel.cleanup()
+        logger.info(f"Cleaned up tunnel :{port}")
+
+    # Also clean up any orphaned artifacts in workers/ directory
+    workers_dir = config.config_dir / 'workers'
+    if workers_dir.exists():
+        for f in workers_dir.iterdir():
+            f.unlink(missing_ok=True)
 
     all_names = list(config.codespace_names) or ([config.codespace_name] if config.codespace_name else [])
     if not all_names:
@@ -605,6 +629,8 @@ def cmd_down(args, config: Config, gh: GitHubManager) -> int:
         logger.info(f"Deleting Codespace: {name}")
         gh.delete_codespace(name, force=True)
 
+    # Step 5: wipe local state and config tracking
+    state.clear_all()
     config.set('codespace_name', '')
     config.set('codespace_names', [])
     config.save()

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -8,6 +8,7 @@ integration with common security tools.
 """
 
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -239,6 +240,18 @@ def cmd_start(args, config: Config, gh: GitHubManager) -> int:
     """Start SOCKS5 proxy tunnel."""
     logger = get_logger()
     check_dependencies(['gh', 'ssh', 'curl'])
+
+    if getattr(config, '_dry_run', False):
+        names = config.codespace_names or ([config.codespace_name] if config.codespace_name else [])
+        if not names:
+            print("[dry-run] No codespace configured. Would prompt for selection.")
+            return 0
+        for i, name in enumerate(names):
+            port = config.socks_port + i
+            print(f"[dry-run] Would start tunnel {name} on port {port}")
+        print("[dry-run] Would generate proxychains config and save settings")
+        return 0
+
     gh.check_auth()
 
     num_proxies = min(config.get('num_proxies', 1), 2)
@@ -283,8 +296,15 @@ def cmd_start(args, config: Config, gh: GitHubManager) -> int:
         port = config.socks_port + i
         t = SSHTunnel(config, name, port=port, pid_suffix=suffix)
         if not t.is_running():
+            if getattr(config, '_dry_run', False):
+                print(f"[dry-run] Would start tunnel {name} on port {port}")
+                continue
             selector.ensure_running(name)
             t.start(start_timeout=30 if i == 0 else 90)
+
+    if getattr(config, '_dry_run', False):
+        print("[dry-run] Would generate proxychains config and save settings")
+        return 0
 
     ProxychainsConfig.generate(config)
     print_usage_examples(config)
@@ -295,6 +315,13 @@ def cmd_start(args, config: Config, gh: GitHubManager) -> int:
 
 def cmd_stop(args, config: Config, gh: GitHubManager) -> int:
     """Stop proxy tunnel."""
+    if getattr(config, '_dry_run', False):
+        print(f"[dry-run] Would stop tunnel for {config.codespace_name or 'active codespace'}")
+        for i in range(1, len(config.codespace_names)):
+            print(f"[dry-run] Would stop tunnel on port {config.socks_port + i}")
+        print("[dry-run] Would stop HTTP proxy")
+        return 0
+
     tunnel = SSHTunnel(config, config.codespace_name or '')
     tunnel.stop()
 
@@ -667,6 +694,105 @@ def cmd_completion(args, config: Config, gh: GitHubManager) -> int:
     return 0
 
 
+def cmd_check(args, config: Config, gh: GitHubManager) -> int:
+    """Run diagnostics and report configuration/dependency health."""
+    logger = get_logger()
+    issues = 0
+    checks = []
+
+    def _ok(msg: str) -> None:
+        checks.append(("PASS", msg))
+
+    def _fail(msg: str) -> None:
+        nonlocal issues
+        issues += 1
+        checks.append(("FAIL", msg))
+
+    # 1. GitHub CLI
+    if shutil.which('gh'):
+        _ok("gh CLI is installed")
+        result = subprocess.run(['gh', 'auth', 'status'], capture_output=True, text=True)
+        if result.returncode == 0:
+            _ok("gh CLI is authenticated")
+        else:
+            _fail("gh CLI is not authenticated (run: gh auth login)")
+    else:
+        _fail("gh CLI is not installed")
+
+    # 2. SSH
+    if shutil.which('ssh'):
+        _ok("ssh is installed")
+    else:
+        _fail("ssh is not installed")
+
+    # 3. curl
+    if shutil.which('curl'):
+        _ok("curl is installed")
+    else:
+        _fail("curl is not installed")
+
+    # 4. proxychains4
+    if shutil.which('proxychains4'):
+        _ok("proxychains4 is installed")
+    else:
+        _fail("proxychains4 is not installed (optional: apt install proxychains-ng)")
+
+    # 5. Config directory / file
+    if config.config_dir.exists():
+        _ok(f"Config directory exists: {config.config_dir}")
+    else:
+        _fail(f"Config directory missing: {config.config_dir}")
+
+    if config.config_file.exists():
+        _ok(f"Config file exists: {config.config_file}")
+    else:
+        _fail(f"Config file missing: {config.config_file}")
+
+    # 6. SSH key
+    key_file = config.config_dir / 'codespace_key'
+    if key_file.exists():
+        _ok(f"SSH key exists: {key_file}")
+    else:
+        _fail(f"SSH key missing: {key_file} (run: cs-proxy keygen)")
+
+    # 7. Port conflicts
+    import socket
+    for port, label in [(config.socks_port, 'SOCKS5'), (config.http_proxy_port, 'HTTP')]:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                s.bind(('127.0.0.1', port))
+                _ok(f"{label} port {port} is available")
+            except OSError:
+                _fail(f"{label} port {port} is already in use")
+
+    # 8. State file health
+    from .state import State
+    try:
+        state = State(config.config_dir)
+        state_data = state.load()
+        tunnels = state_data.get('tunnels', [])
+        if tunnels:
+            _ok(f"State file has {len(tunnels)} tunnel(s)")
+        else:
+            _ok("State file is healthy (no tunnels)")
+    except Exception as e:
+        _fail(f"State file error: {e}")
+
+    # Report
+    print("\n=== cs-proxy Check ===\n")
+    for status, msg in checks:
+        icon = "✓" if status == "PASS" else "✗"
+        print(f"  {icon}  {msg}")
+    print()
+    if issues == 0:
+        print("All checks passed.")
+        return 0
+    else:
+        print(f"{issues} issue(s) found. Run with --verbose for details.")
+        return 1
+
+
 def cmd_help(args, config: Config, gh: GitHubManager) -> int:
     """Show help."""
     show_help()
@@ -705,5 +831,6 @@ COMMANDS = {
     'aliases':      cmd_aliases,
     'pac':          cmd_pac,
     'completion':   cmd_completion,
+    'check':        cmd_check,
     'help':         cmd_help,
 }

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -564,6 +564,54 @@ def cmd_teardown(args, config: Config, gh: GitHubManager) -> int:
     return 0
 
 
+def cmd_down(args, config: Config, gh: GitHubManager) -> int:
+    """Stop proxy and permanently delete all managed Codespaces."""
+    logger = get_logger()
+    check_dependencies(['gh'])
+    gh.check_auth()
+
+    # Step 1: stop tunnels
+    tunnel = SSHTunnel(config, config.codespace_name or '')
+    tunnel.stop()
+    for i in range(1, len(config.codespace_names)):
+        SSHTunnel(config, '', port=config.socks_port + i, pid_suffix=str(i + 1)).stop()
+
+    all_names = list(config.codespace_names) or ([config.codespace_name] if config.codespace_name else [])
+    if not all_names:
+        logger.warning("No Codespace configured.")
+        return 0
+
+    # Step 2: stop codespaces first (clean shutdown before delete)
+    for name in all_names:
+        logger.info(f"Stopping Codespace: {name}")
+        gh.run_gh_command(
+            ['codespace', 'stop', '--codespace', name], check=False
+        )
+
+    # Step 3: confirm deletion
+    if len(all_names) > 1:
+        print(f"\nThis will PERMANENTLY delete {len(all_names)} managed codespaces:")
+        for name in all_names:
+            print(f"  - {name}")
+    else:
+        print(f"\nThis will PERMANENTLY delete: {all_names[0]}")
+    confirm = input("Are you sure? [y/N] ").strip().lower()
+    if confirm != 'y':
+        logger.info("Cancelled — codespaces were stopped but not deleted.")
+        return 0
+
+    # Step 4: delete
+    for name in all_names:
+        logger.info(f"Deleting Codespace: {name}")
+        gh.delete_codespace(name, force=True)
+
+    config.set('codespace_name', '')
+    config.set('codespace_names', [])
+    config.save()
+    logger.info(f"Deleted {len(all_names)} codespace(s)")
+    return 0
+
+
 def cmd_delete(args, config: Config, gh: GitHubManager) -> int:
     """Delete Codespace(s) permanently."""
     logger = get_logger()
@@ -824,7 +872,7 @@ COMMANDS = {
     'run':          cmd_run,
     'name':         cmd_name,
     'teardown':     cmd_teardown,
-    'down':         cmd_teardown,   # Alias
+    'down':         cmd_down,
     'delete':       cmd_delete,
     'rm':           cmd_delete,     # Alias
     'token':        cmd_token,

--- a/csproxy/serve.py
+++ b/csproxy/serve.py
@@ -6,10 +6,13 @@ Hosts files, directories, redirect servers, and custom HTTP response servers
 through a Codespace, producing public HTTPS URLs on app.github.dev.
 """
 
+import shlex
 import subprocess
 import time
 from pathlib import Path
 from typing import Optional
+
+MAX_UPLOAD_BYTES = 100 * 1024 * 1024  # 100 MB cap on file uploads
 
 from .github import GitHubManager
 from .templates import (
@@ -78,6 +81,14 @@ def _get_available_codespace(gh: GitHubManager, config: Config) -> str:
 # =============================================================================
 
 
+def _validate_remote_path(remote_path: str) -> None:
+    """Reject paths that traverse outside the serve directory."""
+    if not remote_path or remote_path.startswith('/'):
+        raise ValueError(f"Absolute paths are not allowed: {remote_path}")
+    if '..' in remote_path:
+        raise ValueError(f"Path traversal is not allowed: {remote_path}")
+
+
 def _ssh(gh: GitHubManager, cs_name: str, command: str,
          stdin: Optional[bytes] = None) -> subprocess.CompletedProcess:
     """
@@ -116,8 +127,9 @@ def _upload_script(gh: GitHubManager, cs_name: str,
         content: Script content to upload
     """
     logger = get_logger()
+    _validate_remote_path(remote_path)
     cmd = ['gh', 'codespace', 'ssh', '--codespace', cs_name,
-           '--', f'cat > {remote_path}']
+           '--', f'cat > {shlex.quote(remote_path)}']
     result = subprocess.run(
         cmd,
         input=content.encode(),
@@ -146,9 +158,16 @@ def _upload_file(gh: GitHubManager, cs_name: str,
         remote_path: Destination path on Codespace
     """
     logger = get_logger()
+    _validate_remote_path(remote_path)
+    size = local_path.stat().st_size
+    if size > MAX_UPLOAD_BYTES:
+        raise ValueError(
+            f"File too large: {local_path.name} is {size / 1024 / 1024:.1f} MB "
+            f"(max {MAX_UPLOAD_BYTES / 1024 / 1024:.0f} MB)"
+        )
     content = local_path.read_bytes()
     cmd = ['gh', 'codespace', 'ssh', '--codespace', cs_name,
-           '--', f'cat > {remote_path}']
+           '--', f'cat > {shlex.quote(remote_path)}']
     result = subprocess.run(
         cmd,
         input=content,
@@ -179,17 +198,18 @@ def _setup_server_environment(gh: GitHubManager, cs_name: str, port: int) -> Non
 
     # Kill old server processes and any process holding the port on Codespace
     _ssh(gh, cs_name,
-         "pkill -9 -f 'redirect_server.py' || true; "
-         "pkill -9 -f 'custom_server.py' || true; "
-         "pkill -9 -f 'server.py' || true; "
-         f"fuser -k -9 {port}/tcp 2>/dev/null || true; "
-         f"lsof -ti:{port} | xargs kill -9 2>/dev/null || true; "
+         f"pkill -9 -f 'csproxy_server_{shlex.quote(str(port))}' || true; "
+         f"pkill -9 -f 'csproxy_redirect_{shlex.quote(str(port))}' || true; "
+         f"pkill -9 -f 'csproxy_custom_{shlex.quote(str(port))}' || true; "
+         f"pkill -9 -f 'csproxy_capture_{shlex.quote(str(port))}' || true; "
+         f"fuser -k -9 {shlex.quote(str(port))}/tcp 2>/dev/null || true; "
+         f"lsof -ti:{shlex.quote(str(port))} | xargs kill -9 2>/dev/null || true; "
          "sleep 2")
 
     # Kill local port forward processes
     try:
         subprocess.run(
-            ['pkill', '-f', f'gh codespace ports forward {port}'],
+            ['pkill', '-f', f'gh codespace ports forward {shlex.quote(str(port))}'],
             capture_output=True
         )
     except FileNotFoundError:
@@ -255,7 +275,7 @@ def _verify_server_running(gh: GitHubManager, cs_name: str, process_name: str) -
         RuntimeError: If server process is not found
     """
     logger = get_logger()
-    result = _ssh(gh, cs_name, f"pgrep -f '{process_name}' && echo OK")
+    result = _ssh(gh, cs_name, f"pgrep -f {shlex.quote(process_name)} && echo OK")
 
     if b'OK' not in result.stdout:
         # Show server log for debugging
@@ -317,12 +337,13 @@ def _download_captures(gh: GitHubManager, cs_name: str) -> None:
     logger.info(f"Downloading {len(files)} capture file(s)...")
 
     for filename in files:
+        _validate_remote_path(f"captures/{filename}")
         remote_path = f"/tmp/serve/captures/{filename}"
         local_path = Path(filename)
 
         dl_result = subprocess.run(
             ['gh', 'codespace', 'ssh', '--codespace', cs_name,
-             '--', f'cat {remote_path}'],
+             '--', f'cat {shlex.quote(remote_path)}'],
             capture_output=True,
             timeout=30
         )
@@ -375,8 +396,8 @@ def _is_server_running(gh: GitHubManager, cs_name: str, script_name: str, port: 
     """
     result = _ssh(
         gh, cs_name,
-        f"pgrep -f '{script_name}' > /dev/null 2>&1 "
-        f"&& ss -tln 2>/dev/null | grep -q ':{port} ' "
+        f"pgrep -f {shlex.quote(script_name)} > /dev/null 2>&1 "
+        f"&& ss -tln 2>/dev/null | grep -q ':{shlex.quote(str(port))} ' "
         f"&& echo RUNNING || true"
     )
     return b'RUNNING' in result.stdout
@@ -417,7 +438,7 @@ def _launch_server(gh: GitHubManager, cs_name: str, port: int,
 
         logger.info(f"Starting server on port {port}...")
         _ssh(gh, cs_name,
-             f"cd {SERVE_DIR}; nohup python3 {script_name} > server.log 2>&1 & sleep 1; exit 0")
+             f"cd {shlex.quote(SERVE_DIR)}; nohup python3 {shlex.quote(script_name)} > server.log 2>&1 & sleep 1; exit 0")
         time.sleep(1)
 
         _verify_server_running(gh, cs_name, script_name)
@@ -441,7 +462,7 @@ def _launch_server(gh: GitHubManager, cs_name: str, port: int,
         fwd.terminate()
         if cf_worker:
             cf_worker.teardown()
-        _ssh(gh, cs_name, f"pkill -9 -f '{script_name}' 2>/dev/null || true")
+        _ssh(gh, cs_name, f"pkill -9 -f {shlex.quote(script_name)} 2>/dev/null || true")
 
 
 # =============================================================================
@@ -487,7 +508,7 @@ def serve_file(file_path: Path, port: int, gh: GitHubManager,
 
     _launch_server(gh, cs_name, port,
                    script=_FILE_SERVER_SCRIPT.format(PORT=port),
-                   script_name="server.py",
+                   script_name=f"csproxy_server_{port}.py",
                    banner_fn=banner, domain=domain, config=config)
 
 
@@ -532,7 +553,7 @@ def serve_directory(dir_path: Path, port: int, gh: GitHubManager,
 
     _launch_server(gh, cs_name, port,
                    script=_FILE_SERVER_SCRIPT.format(PORT=port),
-                   script_name="server.py",
+                   script_name=f"csproxy_server_{port}.py",
                    banner_fn=banner, domain=domain, config=config)
 
 
@@ -575,7 +596,7 @@ def serve_redirect(target_url: str, port: int, redirect_code: int,
                        TARGET_URL=target_url,
                        REDIRECT_CODE=redirect_code,
                        PORT=port),
-                   script_name="redirect_server.py",
+                   script_name=f"csproxy_redirect_{port}.py",
                    banner_fn=banner, domain=domain, config=config)
 
 
@@ -618,7 +639,7 @@ def serve_custom(port: int, response_body: str, content_type: str,
                        CONTENT_TYPE=content_type,
                        STATUS_CODE=status_code,
                        PORT=port),
-                   script_name="custom_server.py",
+                   script_name=f"csproxy_custom_{port}.py",
                    banner_fn=banner, domain=domain, config=config)
 
 
@@ -644,7 +665,7 @@ def serve_capture(port: int, gh: GitHubManager, config: Config = None,
     logger.info(f"Using Codespace: {cs_name}")
     logger.info(f"Port: {port}")
 
-    reconnect = _is_server_running(gh, cs_name, 'capture_server.py', port)
+    reconnect = _is_server_running(gh, cs_name, f'csproxy_capture_{port}.py', port)
 
     if reconnect:
         logger.info("Existing capture server detected — reconnecting...")
@@ -674,7 +695,7 @@ def serve_capture(port: int, gh: GitHubManager, config: Config = None,
 
     _launch_server(gh, cs_name, port,
                    script=_CAPTURE_SERVER_SCRIPT.format(PORT=port),
-                   script_name="capture_server.py",
+                   script_name=f"csproxy_capture_{port}.py",
                    banner_fn=banner, domain=domain, config=config,
                    reconnect=reconnect)
 
@@ -697,11 +718,11 @@ def stop_server(port: int, gh: GitHubManager, config: Config = None) -> None:
     cs_name = _get_available_codespace(gh, config)
 
     logger.info(f"Stopping server on port {port}...")
-    _ssh(gh, cs_name, "pkill -f 'python3.*server.py' 2>/dev/null || true")
+    _ssh(gh, cs_name, "pkill -f 'python3.*csproxy_' 2>/dev/null || true")
 
     try:
         subprocess.run(
-            ['pkill', '-f', f'gh codespace ports forward {port}'],
+            ['pkill', '-f', f'gh codespace ports forward {shlex.quote(str(port))}'],
             capture_output=True
         )
     except FileNotFoundError:
@@ -732,7 +753,7 @@ def clean_all(gh: GitHubManager, config: Config = None) -> None:
 
     logger.info("Killing remote Python servers...")
     _ssh(gh, cs_name,
-         "pkill -f 'python3.*server' || true; "
+         "pkill -f 'python3.*csproxy_' || true; "
          "pkill -f 'python3 -m http.server' || true")
 
     logger.info("Removing /tmp/serve...")

--- a/csproxy/state.py
+++ b/csproxy/state.py
@@ -193,6 +193,12 @@ class State:
             self.save(data)
         return crashed
 
+    def clear_all(self) -> None:
+        """Remove all tunnels from state."""
+        data = self.load()
+        data["tunnels"] = []
+        self.save(data)
+
     def get_tunnels(
         self, kind: Optional[str] = None, status: Optional[str] = None
     ) -> list[dict]:

--- a/csproxy/state.py
+++ b/csproxy/state.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+"""
+Lightweight JSON-based state management for csproxy.
+
+Replaces fragile flat PID files with a single atomic state.json.
+All writes are atomic (tempfile + os.replace) and guarded by a
+spinlock (os.O_CREAT|os.O_EXCL) with stale-lock detection.
+
+Locking notes:
+- os.O_CREAT | os.O_EXCL is atomic on POSIX and on Windows NTFS.
+- On Windows network drives (SMB) the atomicity guarantee may be weaker,
+  so we combine it with mtime-based stale-lock detection as a fallback.
+- The lock file contains the PID of the holder. If that process is dead
+  (or the lock file is older than 30s), we force-break it.
+"""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _pid_exists(pid: int) -> bool:
+    """Check whether a process with the given PID is alive."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+class State:
+    """Thread-safe(ish) JSON state store for tunnel metadata."""
+
+    def __init__(self, config_dir: Path) -> None:
+        self.path = config_dir / "state.json"
+        self._lock_path = config_dir / "state.lock"
+        self._ensure_dir()
+        self._migrate_from_pid_files(config_dir)
+
+    def _ensure_dir(self) -> None:
+        """Create parent directories if they don't exist."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _migrate_from_pid_files(self, config_dir: Path) -> None:
+        """One-time migration from legacy proxy.pid / proxy2.pid files."""
+        if self.path.exists():
+            return
+
+        tunnels = []
+        for pid_file in sorted(config_dir.glob("proxy*.pid")):
+            if pid_file.name.endswith(".stop"):
+                continue
+            try:
+                pid = int(pid_file.read_text().strip())
+                # Derive index from filename: proxy.pid -> 0, proxy2.pid -> 1
+                suffix = pid_file.stem.replace("proxy", "")
+                idx = int(suffix) - 1 if suffix else 0
+                port = 1080 + idx
+                tunnels.append({
+                    "id": f"ssh-{port}",
+                    "kind": "ssh",
+                    "codespace_name": "",
+                    "port": port,
+                    "pid": pid,
+                    "status": "unknown",
+                    "created": 0,
+                    "failures": 0,
+                    "last_failure": 0,
+                })
+            except (ValueError, OSError):
+                continue
+
+        if tunnels:
+            self.save({"version": 1, "tunnels": tunnels})
+            # Clean up old pid files so we never migrate again
+            for f in list(config_dir.glob("proxy*.pid")) + list(config_dir.glob("proxy*.stop")):
+                f.unlink(missing_ok=True)
+        else:
+            self.save({"version": 1, "tunnels": []})
+
+    def _read(self) -> dict:
+        """Read state from disk. Returns a safe default if the file is missing or corrupt."""
+        if not self.path.exists():
+            return {"version": 1, "tunnels": []}
+        try:
+            return json.loads(self.path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {"version": 1, "tunnels": []}
+
+    def _write(self, data: dict) -> None:
+        """Atomically write state to disk using a temp file + os.replace."""
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", dir=str(self.path.parent), delete=False, suffix=".tmp"
+        )
+        try:
+            json.dump(data, tmp, indent=2)
+            tmp.close()
+            os.replace(tmp.name, str(self.path))
+        except Exception:
+            tmp.close()
+            Path(tmp.name).unlink(missing_ok=True)
+            raise
+
+    def _acquire_lock(self, timeout: float = 5.0) -> None:
+        """
+        Acquire an advisory lock using atomic file creation.
+
+        Uses os.O_CREAT | os.O_EXCL which is atomic on POSIX and Windows NTFS.
+        If the lock file already exists, we check whether the owning process is
+        still alive (via the PID stored inside). Dead locks are force-broken.
+        As a fallback for network drives where O_EXCL may be unreliable, locks
+        older than 30 seconds are also considered stale.
+        """
+        start = time.time()
+        my_pid = os.getpid()
+        while True:
+            try:
+                fd = os.open(
+                    str(self._lock_path),
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                )
+                os.write(fd, str(my_pid).encode())
+                os.close(fd)
+                return
+            except FileExistsError:
+                # Stale lock detection: by PID and by mtime
+                try:
+                    lock_pid = int(self._lock_path.read_text().strip())
+                    stale_by_age = (
+                        time.time() - self._lock_path.stat().st_mtime > 30
+                    )
+                    if lock_pid != my_pid and (not _pid_exists(lock_pid) or stale_by_age):
+                        self._lock_path.unlink(missing_ok=True)
+                        continue
+                except (ValueError, OSError):
+                    self._lock_path.unlink(missing_ok=True)
+                    continue
+
+                if time.time() - start > timeout:
+                    raise TimeoutError(
+                        f"Could not acquire state lock ({self._lock_path}). "
+                        "Another cs-proxy process may be running."
+                    )
+                time.sleep(0.05)
+
+    def _release_lock(self) -> None:
+        """Release the advisory lock."""
+        self._lock_path.unlink(missing_ok=True)
+
+    def load(self) -> dict:
+        """Load state under lock."""
+        self._acquire_lock()
+        try:
+            return self._read()
+        finally:
+            self._release_lock()
+
+    def save(self, data: dict) -> None:
+        """Save state under lock."""
+        self._acquire_lock()
+        try:
+            self._write(data)
+        finally:
+            self._release_lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def reconcile(self) -> list[dict]:
+        """
+        Mark dead tunnels as crashed and return the list of newly-crashed entries.
+
+        Call this on every CLI startup so stale state from previous runs is cleaned up.
+        """
+        data = self.load()
+        changed = False
+        crashed = []
+        for t in data.get("tunnels", []):
+            if t.get("status") in ("stopped", "crashed", "dead"):
+                continue
+            pid = t.get("pid")
+            alive = _pid_exists(pid) if pid else False
+            if not alive:
+                t["status"] = "crashed"
+                crashed.append(t)
+                changed = True
+        if changed:
+            self.save(data)
+        return crashed
+
+    def get_tunnels(
+        self, kind: Optional[str] = None, status: Optional[str] = None
+    ) -> list[dict]:
+        """Return all tunnels, optionally filtered by kind and/or status."""
+        data = self.load()
+        tunnels = list(data.get("tunnels", []))
+        if kind:
+            tunnels = [t for t in tunnels if t.get("kind") == kind]
+        if status:
+            tunnels = [t for t in tunnels if t.get("status") == status]
+        return tunnels
+
+    def get_tunnel_by_port(self, port: int) -> Optional[dict]:
+        """Return the tunnel dict for the given port, or None."""
+        for t in self.get_tunnels():
+            if t.get("port") == port:
+                return t
+        return None
+
+    def add_tunnel(self, **fields: Any) -> None:
+        """Add or replace a tunnel entry by its 'id'."""
+        data = self.load()
+        tunnels = [t for t in data.get("tunnels", []) if t.get("id") != fields.get("id")]
+        tunnels.append(fields)
+        data["tunnels"] = tunnels
+        self.save(data)
+
+    def remove_tunnel(
+        self, port: Optional[int] = None, tunnel_id: Optional[str] = None
+    ) -> None:
+        """Remove a tunnel by port and/or tunnel_id."""
+        data = self.load()
+        tunnels = data.get("tunnels", [])
+        if port is not None:
+            tunnels = [t for t in tunnels if t.get("port") != port]
+        if tunnel_id is not None:
+            tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
+        data["tunnels"] = tunnels
+        self.save(data)
+
+    def update_tunnel(self, port: int, **kwargs: Any) -> None:
+        """Update fields for the tunnel matching the given port."""
+        data = self.load()
+        for t in data.get("tunnels", []):
+            if t.get("port") == port:
+                t.update(kwargs)
+                break
+        self.save(data)
+
+    def mark_crashed(self, port: int) -> None:
+        """Convenience wrapper to mark a tunnel as crashed."""
+        self.update_tunnel(port, status="crashed")
+
+    def record_failure(
+        self, port: int, max_failures: int = 3, window: int = 600
+    ) -> bool:
+        """
+        Record a health-check failure for the tunnel on the given port.
+
+        Returns True if the circuit breaker tripped (status set to 'dead').
+        """
+        data = self.load()
+        for t in data.get("tunnels", []):
+            if t.get("port") == port:
+                now = int(time.time())
+                last = t.get("last_failure", 0)
+                if now - last > window:
+                    t["failures"] = 0
+                t["failures"] = t.get("failures", 0) + 1
+                t["last_failure"] = now
+                if t["failures"] >= max_failures:
+                    t["status"] = "dead"
+                self.save(data)
+                return t["status"] == "dead"
+        return False

--- a/csproxy/templates.py
+++ b/csproxy/templates.py
@@ -23,7 +23,11 @@ def start_server(handler, port, retries=5):
         except OSError as e:
             if attempt < retries - 1:
                 print(f'Port {{port}} busy, killing and retrying ({{attempt+1}}/{{retries}})...', flush=True)
-                subprocess.run(f'fuser -k -9 {{port}}/tcp 2>/dev/null; lsof -ti:{{port}} | xargs kill -9 2>/dev/null', shell=True)
+                subprocess.run(['fuser', '-k', '-9', f'{{port}}/tcp'],
+                               capture_output=True)
+                subprocess.run(['sh', '-c',
+                                f'lsof -ti:{{port}} | xargs kill -9 2>/dev/null'],
+                               capture_output=True)
                 time.sleep(2)
             else:
                 raise

--- a/csproxy/tools.py
+++ b/csproxy/tools.py
@@ -15,14 +15,32 @@ Or via the CLI:
 """
 
 import os
+import random
 import subprocess
 import sys
 from pathlib import Path
 from typing import List, Optional
 
+from .state import State
 from .utils import Config, get_logger
 
 VERSION = "1.0.0"
+
+
+def _get_proxy_port(config: Config) -> int:
+    """
+    Return a random healthy tunnel port from state.json, or fall back
+    to config.socks_port if no healthy tunnels are tracked.
+    """
+    try:
+        state = State(config.config_dir)
+        healthy = state.get_tunnels(kind="ssh", status="healthy")
+        if healthy:
+            return random.choice(healthy)["port"]
+    except Exception:
+        pass
+    return config.socks_port
+
 
 # Default wordlist paths (SecLists)
 SECLISTS = Path(os.environ.get('SECLISTS', Path.home() / 'wordlists' / 'SecLists'))
@@ -48,7 +66,7 @@ def check_proxy(host: str = '127.0.0.1', port: Optional[int] = None) -> bool:
         True if proxy is up, False otherwise.
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     result = subprocess.run(
         ['curl', '-s', '--connect-timeout', '2',
          '--socks5', f'{host}:{port}', 'https://ifconfig.me'],
@@ -82,7 +100,7 @@ def pcurl(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         curl exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
@@ -105,7 +123,7 @@ def pwget(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         wget exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
@@ -131,7 +149,7 @@ def pnmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         nmap exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
@@ -157,7 +175,7 @@ def pnuclei(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
         nuclei exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
     env = os.environ.copy()
@@ -180,7 +198,7 @@ def pffuf(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         ffuf exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
@@ -203,7 +221,7 @@ def phttpx(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None)
         httpx exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
@@ -226,7 +244,7 @@ def psqlmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
         sqlmap exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
@@ -249,7 +267,7 @@ def pcs(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) ->
         Command exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
@@ -270,7 +288,7 @@ def ipcheck(host: str = '127.0.0.1', port: Optional[int] = None) -> None:
     Equivalent to ipcheck() in tools-wrapper.sh.
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
 
     # Direct IP
     result = subprocess.run(
@@ -314,7 +332,7 @@ def psub(domain: str, host: str = '127.0.0.1', port: Optional[int] = None) -> in
     """
     import shutil
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
 
     if not domain:
         print("Usage: psub domain.com")
@@ -358,7 +376,7 @@ def pportscan(target: str, ports: str = '21,22,23,25,80,443,445,3306,3389,8080,8
         Exit code
     """
     config = Config()
-    port = port or config.socks_port
+    port = port or _get_proxy_port(config)
 
     if not target:
         print("Usage: pportscan target [ports]")

--- a/csproxy/tools.py
+++ b/csproxy/tools.py
@@ -69,7 +69,7 @@ def check_proxy(host: str = '127.0.0.1', port: Optional[int] = None) -> bool:
     port = port or _get_proxy_port(config)
     result = subprocess.run(
         ['curl', '-s', '--connect-timeout', '2',
-         '--socks5', f'{host}:{port}', 'https://ifconfig.me'],
+         '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me'],
         capture_output=True
     )
     if result.returncode != 0:

--- a/csproxy/tunnel.py
+++ b/csproxy/tunnel.py
@@ -191,11 +191,70 @@ class SSHTunnel:
 
         self.pid_file.unlink(missing_ok=True)
         self.spec_file.unlink(missing_ok=True)
+        self.spec_file.with_suffix('.stderr').unlink(missing_ok=True)
         self.state.remove_tunnel(port=self.port)
         self.logger.info("Proxy stopped")
 
+    def cleanup(self) -> None:
+        """
+        Aggressive cleanup: kill any lingering worker, remove all artifacts,
+        and purge the state entry. Use when a tunnel is known to be stale.
+        """
+        self.logger.debug(f"Aggressive cleanup for tunnel :{self.port}")
+
+        # Try to kill by PID file
+        pid = self._read_pid()
+        if pid:
+            for sig in (signal.SIGTERM, signal.SIGKILL):
+                try:
+                    os.kill(pid, sig)
+                    time.sleep(0.2)
+                    os.kill(pid, 0)
+                except (ProcessLookupError, PermissionError):
+                    break
+
+        # Kill any process still listening on our port (last resort)
+        self._kill_port_holders()
+
+        # Remove all artifacts
+        self.pid_file.unlink(missing_ok=True)
+        self.stop_file.unlink(missing_ok=True)
+        self.spec_file.unlink(missing_ok=True)
+        self.spec_file.with_suffix('.stderr').unlink(missing_ok=True)
+        self.state.remove_tunnel(port=self.port)
+
+    def _kill_port_holders(self) -> None:
+        """Kill processes listening on our SOCKS port (platform-specific)."""
+        try:
+            if sys.platform == 'darwin':
+                # lsof -ti:port gives PIDs
+                result = subprocess.run(
+                    ['lsof', '-ti', f':{self.port}'],
+                    capture_output=True, text=True, timeout=5
+                )
+                if result.returncode == 0:
+                    for pid_str in result.stdout.strip().splitlines():
+                        try:
+                            os.kill(int(pid_str), signal.SIGKILL)
+                        except (ValueError, ProcessLookupError, PermissionError):
+                            pass
+            elif sys.platform == 'linux':
+                result = subprocess.run(
+                    ['fuser', '-k', f'{self.port}/tcp'],
+                    capture_output=True, timeout=5
+                )
+        except Exception:
+            pass
+
     def is_running(self) -> bool:
         """Check if the tunnel process is still alive."""
+        # If state says dead/crashed, trust that over PID existence
+        # (prevents zombies where worker is alive but circuit breaker tripped)
+        state_tunnel = self.state.get_tunnel_by_port(self.port)
+        if state_tunnel and state_tunnel.get('status') in ('dead', 'crashed'):
+            self._cleanup_stale()
+            return False
+
         pid = self._read_pid()
         if not pid:
             return False

--- a/csproxy/tunnel.py
+++ b/csproxy/tunnel.py
@@ -6,6 +6,7 @@ Contains SSHTunnel (SOCKS5 via SSH) and HTTPProxyManager (tinyproxy with
 SOCKS upstream). Extracted from proxy.py for modularity.
 """
 
+import json
 import os
 import shutil
 import signal
@@ -15,6 +16,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from .state import State
 from .utils import Config, ProxyError, SSHTunnelError, get_logger
 
 
@@ -36,11 +38,17 @@ class SSHTunnel:
         self.pid_file = config.config_dir / f'proxy{pid_suffix}.pid'
         self.stop_file = config.config_dir / f'proxy{pid_suffix}.pid.stop'
         self.log_file = config.config_dir / f'proxy{pid_suffix}.log'
+        self.spec_file = config.config_dir / 'workers' / f'{self.port}.json'
+        self.state = State(config.config_dir)
+        self.tunnel_id = f'ssh-{self.port}'
         self._process: Optional[subprocess.Popen] = None
 
     def start(self, start_timeout: int = 30) -> None:
         """
         Start SSH tunnel with SOCKS5 forwarding and auto-reconnect.
+
+        Spawns a detached subprocess worker that runs the reconnect loop,
+        so the tunnel survives terminal death and works cross-platform.
 
         Args:
             start_timeout: Seconds to wait for the SOCKS5 listener to become healthy.
@@ -51,13 +59,12 @@ class SSHTunnel:
             SSHTunnelError: If tunnel cannot be established
         """
         if self.is_running():
-            self.logger.warning(f"Proxy already running (PID: {self._read_pid()})")
+            self.logger.warning(f"Proxy already running on port {self.port}")
             return
 
         self.logger.info(f"Starting SOCKS5 proxy on port {self.port}...")
-
-        if self.stop_file.exists():
-            self.stop_file.unlink()
+        self.stop_file.unlink(missing_ok=True)
+        self.spec_file.parent.mkdir(parents=True, exist_ok=True)
 
         ssh_args = [
             '--',
@@ -66,28 +73,65 @@ class SSHTunnel:
             '-o', 'ServerAliveInterval=30',
             '-o', 'ServerAliveCountMax=3',
             '-o', 'ExitOnForwardFailure=yes',
-            # Disable ControlMaster so concurrent tunnels to different codespaces
-            # don't share the same relay socket (all codespaces use the same SSH
-            # relay hostname, e.g. vs-ssh.github.dev).  Without this, the second
-            # tunnel hangs waiting to multiplex over the first tunnel's socket.
             '-o', 'ControlMaster=no',
             '-o', 'ControlPath=none',
         ]
 
         gh_cmd = ['gh', 'codespace', 'ssh', '--codespace', self.codespace_name] + ssh_args
 
-        env = os.environ.copy()
+        spec = {
+            'gh_cmd': gh_cmd,
+            'log_file': str(self.log_file),
+            'stop_file': str(self.stop_file),
+            'reconnect_delay': self.config.reconnect_delay,
+            'max_reconnect_delay': self.config.max_reconnect_delay,
+        }
+        self.spec_file.write_text(json.dumps(spec))
 
-        pid = os.fork() if hasattr(os, 'fork') else None
+        worker_cmd = [sys.executable, '-m', 'csproxy._worker', str(self.spec_file)]
 
-        if pid is not None:
-            if pid == 0:
-                self._run_with_reconnect(gh_cmd, env)
-                sys.exit(0)
-            else:
-                self._write_pid(pid)
+        popen_kwargs = {}
+        if sys.platform == 'win32':
+            popen_kwargs['creationflags'] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+            )
         else:
-            self._run_windows_background(gh_cmd, env)
+            popen_kwargs['start_new_session'] = True
+
+        proc = subprocess.Popen(
+            worker_cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            **popen_kwargs,
+        )
+        self._process = proc
+        self._write_pid(proc.pid)
+
+        # Quick verification: ensure the worker didn't crash immediately
+        # and that it still has its spec file (proves it started reading it)
+        time.sleep(0.3)
+        if proc.poll() is not None:
+            self.spec_file.unlink(missing_ok=True)
+            raise SSHTunnelError(
+                f"Tunnel worker exited immediately with code {proc.returncode}. "
+                f"Check that 'python -m csproxy._worker' is executable."
+            )
+        if not self.spec_file.exists():
+            raise SSHTunnelError(
+                "Tunnel worker started but spec file was cleaned up unexpectedly."
+            )
+
+        self.state.add_tunnel(
+            id=self.tunnel_id,
+            kind='ssh',
+            codespace_name=self.codespace_name,
+            port=self.port,
+            pid=proc.pid,
+            status='starting',
+            created=int(time.time()),
+            failures=0,
+            last_failure=0,
+        )
 
         self.logger.info(f"Waiting for tunnel to establish (timeout: {start_timeout}s)...")
         deadline = time.time() + start_timeout
@@ -96,9 +140,11 @@ class SSHTunnel:
             time.sleep(3)
             attempt += 1
             if not self.is_running():
+                self.state.mark_crashed(self.port)
                 raise SSHTunnelError("Tunnel process exited immediately - check logs")
             self.logger.debug(f"Health check attempt {attempt} on port {self.port}...")
             if self.health_check():
+                self.state.update_tunnel(self.port, status='healthy')
                 break
         else:
             self.stop()
@@ -110,49 +156,6 @@ class SSHTunnel:
         self.logger.info("SOCKS5 proxy started successfully")
         self.logger.info(f"  Local endpoint: socks5://127.0.0.1:{self.port}")
 
-    def _run_with_reconnect(self, gh_cmd: list, env: Optional[dict] = None) -> None:
-        """Run SSH tunnel with exponential backoff reconnect."""
-        delay = self.config.reconnect_delay
-
-        while True:
-            if self.stop_file.exists():
-                self.stop_file.unlink()
-                break
-
-            log_mode = 'a' if self.log_file.exists() else 'w'
-            with open(self.log_file, log_mode) as log_fd:
-                process = subprocess.run(
-                    gh_cmd,
-                    stdout=log_fd,
-                    stderr=log_fd,
-                    env=env,
-                )
-
-            if self.stop_file.exists():
-                self.stop_file.unlink()
-                break
-
-            with open(self.log_file, 'a') as log_fd:
-                log_fd.write(
-                    f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] "
-                    f"SSH tunnel disconnected (exit: {process.returncode}). "
-                    f"Reconnecting in {delay}s...\n"
-                )
-
-            time.sleep(delay)
-            delay = min(delay * 2, self.config.max_reconnect_delay)
-
-    def _run_windows_background(self, gh_cmd: list, env: Optional[dict] = None) -> None:
-        """Start tunnel in background thread on Windows (no fork available)."""
-        import threading
-
-        def run():
-            self._run_with_reconnect(gh_cmd, env)
-
-        thread = threading.Thread(target=run, daemon=True)
-        thread.start()
-        self._write_pid(os.getpid())
-
     def stop(self) -> None:
         """Stop the SSH tunnel."""
         self.stop_file.touch()
@@ -161,25 +164,21 @@ class SSHTunnel:
         if pid:
             try:
                 os.kill(pid, signal.SIGTERM)
-                time.sleep(2)
-                try:
+                # Poll for up to 2s for graceful exit
+                for _ in range(20):
+                    time.sleep(0.1)
+                    try:
+                        os.kill(pid, 0)
+                    except ProcessLookupError:
+                        break
+                else:
                     os.kill(pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-            except ProcessLookupError:
+            except (ProcessLookupError, PermissionError):
                 pass
 
-        if self.pid_file.exists():
-            self.pid_file.unlink()
-
-        try:
-            subprocess.run(
-                ['pkill', '-f', f'gh codespace ssh.*-D.*{self.port}'],
-                capture_output=True
-            )
-        except FileNotFoundError:
-            pass
-
+        self.pid_file.unlink(missing_ok=True)
+        self.spec_file.unlink(missing_ok=True)
+        self.state.remove_tunnel(port=self.port)
         self.logger.info("Proxy stopped")
 
     def is_running(self) -> bool:
@@ -192,7 +191,14 @@ class SSHTunnel:
             os.kill(pid, 0)
             return True
         except (ProcessLookupError, PermissionError):
+            self._cleanup_stale()
             return False
+
+    def _cleanup_stale(self) -> None:
+        """Remove stale PID files and state entries for dead processes."""
+        self.pid_file.unlink(missing_ok=True)
+        self.spec_file.unlink(missing_ok=True)
+        self.state.remove_tunnel(port=self.port)
 
     def health_check(self, timeout: int = 5) -> bool:
         """Verify the SOCKS5 proxy is responding."""
@@ -200,6 +206,7 @@ class SSHTunnel:
             [
                 'curl', '-s',
                 '--connect-timeout', str(timeout),
+                '--max-time', str(timeout + 2),
                 '--socks5-hostname', f'127.0.0.1:{self.port}',
                 'https://ifconfig.me'
             ],

--- a/csproxy/tunnel.py
+++ b/csproxy/tunnel.py
@@ -98,10 +98,13 @@ class SSHTunnel:
         else:
             popen_kwargs['start_new_session'] = True
 
+        # Redirect stderr to a file so we can surface it if the worker
+        # crashes immediately (e.g., import error, bad spec).
+        stderr_file = self.spec_file.with_suffix('.stderr')
         proc = subprocess.Popen(
             worker_cmd,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=open(stderr_file, 'w'),
             **popen_kwargs,
         )
         self._process = proc
@@ -111,11 +114,21 @@ class SSHTunnel:
         # and that it still has its spec file (proves it started reading it)
         time.sleep(0.3)
         if proc.poll() is not None:
+            stderr_text = ""
+            try:
+                if stderr_file.exists():
+                    stderr_text = stderr_file.read_text().strip()
+                    stderr_file.unlink(missing_ok=True)
+            except OSError:
+                pass
             self.spec_file.unlink(missing_ok=True)
-            raise SSHTunnelError(
+            msg = (
                 f"Tunnel worker exited immediately with code {proc.returncode}. "
                 f"Check that 'python -m csproxy._worker' is executable."
             )
+            if stderr_text:
+                msg += f" Worker stderr: {stderr_text[:500]}"
+            raise SSHTunnelError(msg)
         if not self.spec_file.exists():
             raise SSHTunnelError(
                 "Tunnel worker started but spec file was cleaned up unexpectedly."
@@ -213,7 +226,19 @@ class SSHTunnel:
             capture_output=True,
             timeout=timeout + 5
         )
-        return result.returncode == 0
+        healthy = result.returncode == 0
+        if healthy:
+            # Reset failure counter on success
+            self.state.update_tunnel(self.port, failures=0, last_failure=0)
+        else:
+            # Record failure and trip circuit breaker if threshold exceeded
+            tripped = self.state.record_failure(self.port)
+            if tripped:
+                self.logger.warning(
+                    f"Circuit breaker tripped for tunnel :{self.port}. "
+                    f"Tunnel marked as dead — manual restart required."
+                )
+        return healthy
 
     def get_exit_ip(self) -> Optional[str]:
         """Get the exit IP address through the proxy."""

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -171,9 +171,14 @@ class Config:
                     config_file=str(self.config_file),
                 )
 
-            known = {f.name for f in fields(_ConfigData)} | self.DEPRECATED_KEYS
+            known = {f.name for f in fields(_ConfigData)}
             for key in loaded:
-                if key not in known:
+                if key in self.DEPRECATED_KEYS:
+                    self.logger.warning(
+                        f"Deprecated config key '{key}' will be ignored. "
+                        f"Please remove it from {self.config_file}"
+                    )
+                elif key not in known:
                     self.logger.warning(f"Unknown config key: {key}")
 
             self._extra = {k: v for k, v in loaded.items() if k not in known}

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -2,13 +2,14 @@
 """
 Configuration management for cs-proxy toolkit.
 
-Provides YAML-based configuration with defaults and environment variable
-overrides, replacing shell variable sourcing from Bash config files.
+Provides YAML-based configuration with defaults, validation, profiles,
+and environment variable overrides.
 """
 
 import os
+from dataclasses import asdict, dataclass, field, fields
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 try:
     import yaml
@@ -20,300 +21,276 @@ from .errors import ConfigError
 from .logging import get_logger
 
 
+@dataclass
+class _ConfigData:
+    """Typed configuration schema with validation."""
+
+    socks_port: int = 1080
+    http_proxy_port: int = 8080
+    num_proxies: int = 1
+    codespace_name: str = ""
+    reconnect_delay: int = 5
+    max_reconnect_delay: int = 300
+    dns_proxy: bool = False
+    verbose: bool = False
+    cloudflare_api_token: str = ""
+    cloudflare_account_id: str = ""
+    locations: List[str] = field(default_factory=list)
+    codespace_names: List[str] = field(default_factory=list)
+    profile: str = ""
+    profiles: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "_ConfigData":
+        """Build from a raw dict, merging active profile if set."""
+        profile_name = raw.get("profile", "")
+        profiles = raw.get("profiles", {})
+        if profile_name and profile_name in profiles:
+            merged = {**raw, **profiles[profile_name]}
+        else:
+            merged = raw
+        known = {f.name for f in fields(cls)}
+        clean = {k: v for k, v in merged.items() if k in known}
+        return cls(**clean)
+
+    def __post_init__(self) -> None:
+        if not 1024 <= self.socks_port <= 65535:
+            raise ValueError(f"socks_port must be 1024-65535, got {self.socks_port}")
+        if not 1024 <= self.http_proxy_port <= 65535:
+            raise ValueError(
+                f"http_proxy_port must be 1024-65535, got {self.http_proxy_port}"
+            )
+        if not 1 <= self.num_proxies <= 5:
+            raise ValueError(f"num_proxies must be 1-5, got {self.num_proxies}")
+        if self.reconnect_delay < 1:
+            raise ValueError(f"reconnect_delay must be >= 1, got {self.reconnect_delay}")
+        if self.max_reconnect_delay < self.reconnect_delay:
+            raise ValueError("max_reconnect_delay must be >= reconnect_delay")
+
+    def set_field(self, key: str, value: Any) -> None:
+        """Set a field with full schema re-validation."""
+        if not hasattr(self, key):
+            raise KeyError(f"Unknown config key: {key}")
+        temp = asdict(self)
+        temp[key] = value
+        validated = _ConfigData(**temp)
+        for f in fields(self):
+            setattr(self, f.name, getattr(validated, f.name))
+
+
 class Config:
     """
     Configuration manager for cs-proxy.
 
-    Handles loading from YAML files, environment variables, and provides
-    default values. Supports both reading and writing configuration.
+    Backed by a dataclass schema for validation, with YAML persistence,
+    environment variable overrides, and profile support.
     """
 
-    # Keys removed from DEFAULTS but still accepted silently so existing
-    # config files don't produce spurious warnings after an upgrade.
-    DEPRECATED_KEYS = {'chain'}
-
-    # Default configuration values
+    DEPRECATED_KEYS = {"chain"}
     DEFAULTS = {
-        # Proxy settings
-        'socks_port': 1080,
-        'http_proxy_port': 8080,
-        'num_proxies': 1,
-
-        # Codespace settings
-        'codespace_name': '',
-
-        # Connection settings
-        'reconnect_delay': 5,
-        'max_reconnect_delay': 300,
-
-        # Advanced settings
-        'dns_proxy': False,
-        'verbose': False,
-
-        # Cloudflare Worker settings
-        'cloudflare_api_token': '',
-        'cloudflare_account_id': '',
-
-        # Codespace creation settings
-        'locations': [],
-
-        # Tracked managed codespaces (all names, not just the active tunnel)
-        'codespace_names': [],
+        "socks_port": 1080,
+        "http_proxy_port": 8080,
+        "num_proxies": 1,
+        "codespace_name": "",
+        "reconnect_delay": 5,
+        "max_reconnect_delay": 300,
+        "dns_proxy": False,
+        "verbose": False,
+        "cloudflare_api_token": "",
+        "cloudflare_account_id": "",
+        "locations": [],
+        "codespace_names": [],
+        "profile": "",
+        "profiles": {},
     }
 
-    def __init__(self, config_dir: Optional[Path] = None, config_file: Optional[Path] = None):
-        """
-        Initialize configuration manager.
-
-        Args:
-            config_dir: Configuration directory (default: ~/.config/cs-proxy)
-            config_file: Configuration file path (default: config_dir/config.yaml)
-        """
+    def __init__(
+        self,
+        config_dir: Optional[Path] = None,
+        config_file: Optional[Path] = None,
+    ):
         self.logger = get_logger()
-
-        # Set configuration directory
-        self.config_dir = config_dir or Path.home() / '.config' / 'cs-proxy'
-
-        # Set configuration file
+        self.config_dir = config_dir or Path.home() / ".config" / "cs-proxy"
         if config_file:
             self.config_file = Path(config_file)
         else:
-            self.config_file = self.config_dir / 'config.yaml'
+            self.config_file = self.config_dir / "config.yaml"
 
-        # Initialize with defaults
-        self._config = self.DEFAULTS.copy()
+        self._data = _ConfigData()
+        self._extra: dict = {}  # Unknown keys preserved across save/load
 
-        # Load from file if exists
         if self.config_file.exists():
             self.load()
         else:
             self.logger.debug(f"Config file not found: {self.config_file}")
 
-        # Apply environment variable overrides
         self._apply_env_overrides()
 
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides to configuration."""
         env_mappings = {
-            'SOCKS_PORT': ('socks_port', int),
-            'HTTP_PROXY_PORT': ('http_proxy_port', int),
-            'CODESPACE_NAME': ('codespace_name', str),
-            'RECONNECT_DELAY': ('reconnect_delay', int),
-            'MAX_RECONNECT_DELAY': ('max_reconnect_delay', int),
-            'DNS_PROXY': ('dns_proxy', lambda x: x.lower() in ('true', '1', 'yes')),
-            'VERBOSE': ('verbose', lambda x: x.lower() in ('true', '1', 'yes')),
-            'NUM_PROXIES': ('num_proxies', int),
-            'CLOUDFLARE_API_TOKEN': ('cloudflare_api_token', str),
-            'CLOUDFLARE_ACCOUNT_ID': ('cloudflare_account_id', str),
-            'LOCATIONS': ('locations', lambda x: [v.strip() for v in x.split(',') if v.strip()]),
+            "SOCKS_PORT": ("socks_port", int),
+            "HTTP_PROXY_PORT": ("http_proxy_port", int),
+            "CODESPACE_NAME": ("codespace_name", str),
+            "RECONNECT_DELAY": ("reconnect_delay", int),
+            "MAX_RECONNECT_DELAY": ("max_reconnect_delay", int),
+            "DNS_PROXY": ("dns_proxy", lambda x: x.lower() in ("true", "1", "yes")),
+            "VERBOSE": ("verbose", lambda x: x.lower() in ("true", "1", "yes")),
+            "NUM_PROXIES": ("num_proxies", int),
+            "CLOUDFLARE_API_TOKEN": ("cloudflare_api_token", str),
+            "CLOUDFLARE_ACCOUNT_ID": ("cloudflare_account_id", str),
+            "LOCATIONS": ("locations", lambda x: [v.strip() for v in x.split(",") if v.strip()]),
         }
 
         for env_var, (config_key, converter) in env_mappings.items():
             value = os.environ.get(env_var)
             if value is not None:
                 try:
-                    self._config[config_key] = converter(value)
+                    setattr(self._data, config_key, converter(value))
                     self.logger.debug(f"Overriding {config_key} from environment: {value}")
                 except (ValueError, TypeError) as e:
                     self.logger.warning(f"Invalid value for {env_var}: {value} ({e})")
 
-    def load(self) -> None:
-        """
-        Load configuration from YAML file.
+    # ------------------------------------------------------------------
+    # Load / Save
+    # ------------------------------------------------------------------
 
-        Raises:
-            ConfigError: If configuration file is invalid or cannot be read
-        """
+    def load(self) -> None:
+        """Load configuration from YAML file."""
         if not YAML_AVAILABLE:
             self.logger.warning("PyYAML not installed, using defaults only")
             return
 
         try:
-            with open(self.config_file, 'r') as f:
+            with open(self.config_file, "r") as f:
                 loaded = yaml.safe_load(f) or {}
 
-            # Validate loaded config
             if not isinstance(loaded, dict):
                 raise ConfigError(
                     f"Invalid config format (expected dict, got {type(loaded).__name__})",
-                    config_file=str(self.config_file)
+                    config_file=str(self.config_file),
                 )
 
-            # Update config with loaded values
-            for key, value in loaded.items():
-                if key in self.DEFAULTS:
-                    self._config[key] = value
-                elif key in self.DEPRECATED_KEYS:
-                    self.logger.debug(f"Ignoring deprecated config key: {key}")
-                else:
+            known = {f.name for f in fields(_ConfigData)} | self.DEPRECATED_KEYS
+            for key in loaded:
+                if key not in known:
                     self.logger.warning(f"Unknown config key: {key}")
 
+            self._extra = {k: v for k, v in loaded.items() if k not in known}
+            self._data = _ConfigData.from_dict(loaded)
             self.logger.debug(f"Loaded configuration from {self.config_file}")
 
         except FileNotFoundError:
             self.logger.debug(f"Config file not found: {self.config_file}")
         except yaml.YAMLError as e:
             raise ConfigError(
-                f"Invalid YAML syntax: {e}",
-                config_file=str(self.config_file)
+                f"Invalid YAML syntax: {e}", config_file=str(self.config_file)
             )
         except (OSError, PermissionError) as e:
             raise ConfigError(
-                f"Cannot read config file: {e}",
-                config_file=str(self.config_file)
+                f"Cannot read config file: {e}", config_file=str(self.config_file)
+            )
+        except (ValueError, TypeError) as e:
+            raise ConfigError(
+                f"Invalid configuration value: {e}", config_file=str(self.config_file)
             )
 
     def save(self) -> None:
-        """
-        Save current configuration to YAML file.
-
-        Raises:
-            ConfigError: If configuration cannot be saved
-        """
+        """Save current configuration to YAML file."""
         if not YAML_AVAILABLE:
             raise ConfigError("PyYAML not installed, cannot save config")
 
         try:
-            # Ensure config directory exists
             self.config_dir.mkdir(parents=True, exist_ok=True)
-
-            # Write configuration
-            with open(self.config_file, 'w') as f:
-                yaml.dump(self._config, f, default_flow_style=False, sort_keys=False)
-
-            # Set secure permissions
+            data_dict = asdict(self._data)
+            data_dict.update(self._extra)
+            with open(self.config_file, "w") as f:
+                yaml.dump(data_dict, f, default_flow_style=False, sort_keys=False)
             self.config_file.chmod(0o600)
-
             self.logger.info(f"Configuration saved to {self.config_file}")
-
         except (OSError, PermissionError) as e:
             raise ConfigError(
-                f"Cannot write config file: {e}",
-                config_file=str(self.config_file)
+                f"Cannot write config file: {e}", config_file=str(self.config_file)
             )
 
+    # ------------------------------------------------------------------
+    # Get / Set
+    # ------------------------------------------------------------------
+
     def get(self, key: str, default: Any = None) -> Any:
-        """
-        Get configuration value.
-
-        Args:
-            key: Configuration key
-            default: Default value if key not found
-
-        Returns:
-            Configuration value or default
-
-        Example:
-            >>> config = Config()
-            >>> port = config.get('socks_port')
-            >>> print(port)
-            1080
-        """
-        return self._config.get(key, default)
+        """Get configuration value."""
+        return getattr(self._data, key, default)
 
     def set(self, key: str, value: Any) -> None:
-        """
-        Set configuration value.
-
-        Args:
-            key: Configuration key
-            value: Configuration value
-
-        Example:
-            >>> config = Config()
-            >>> config.set('socks_port', 9050)
-            >>> config.save()
-        """
-        self._config[key] = value
-        self.logger.debug(f"Set {key} = {value}")
+        """Set configuration value with validation."""
+        try:
+            self._data.set_field(key, value)
+            self.logger.debug(f"Set {key} = {value}")
+        except (KeyError, ValueError, TypeError) as e:
+            self.logger.warning(f"Invalid config value for {key}: {e}")
 
     def to_dict(self) -> dict:
-        """
-        Get configuration as dictionary.
-
-        Returns:
-            Configuration dictionary
-        """
-        return self._config.copy()
+        """Get configuration as dictionary."""
+        return asdict(self._data)
 
     def ensure_dirs(self) -> None:
-        """
-        Ensure all required directories exist.
-
-        Creates:
-            - Config directory (~/.config/cs-proxy)
-        """
+        """Ensure all required directories exist."""
         self.config_dir.mkdir(parents=True, exist_ok=True)
         self.config_dir.chmod(0o700)
         self.logger.debug(f"Ensured config directory: {self.config_dir}")
 
+    # ------------------------------------------------------------------
+    # Properties (backward-compatible API)
+    # ------------------------------------------------------------------
+
     @property
     def socks_port(self) -> int:
-        """Get SOCKS5 proxy port."""
-        return self._config['socks_port']
+        return self._data.socks_port
 
     @property
     def http_proxy_port(self) -> int:
-        """Get HTTP proxy port."""
-        return self._config['http_proxy_port']
+        return self._data.http_proxy_port
 
     @property
     def codespace_name(self) -> str:
-        """Get Codespace name."""
-        return self._config['codespace_name']
+        return self._data.codespace_name
 
     @property
     def reconnect_delay(self) -> int:
-        """Get reconnect delay in seconds."""
-        return self._config['reconnect_delay']
+        return self._data.reconnect_delay
 
     @property
     def max_reconnect_delay(self) -> int:
-        """Get maximum reconnect delay in seconds."""
-        return self._config['max_reconnect_delay']
+        return self._data.max_reconnect_delay
 
     @property
     def dns_proxy(self) -> bool:
-        """Get DNS proxy setting."""
-        return self._config['dns_proxy']
+        return self._data.dns_proxy
 
     @property
     def num_proxies(self) -> int:
-        """Get number of proxy tunnels for round-robin."""
-        return self._config.get('num_proxies', 1)
+        return self._data.num_proxies
 
     @property
     def verbose(self) -> bool:
-        """Get verbose logging setting."""
-        return self._config['verbose']
+        return self._data.verbose
 
     @property
     def locations(self) -> list:
-        """Get preferred Codespace creation locations."""
-        return self._config.get('locations', [])
+        return self._data.locations
 
     @property
     def location(self) -> str:
-        """Get first preferred location, or empty string if none set."""
-        locs = self.locations
-        return locs[0] if locs else ''
+        locs = self._data.locations
+        return locs[0] if locs else ""
 
     @property
     def codespace_names(self) -> list:
-        """Get all managed Codespace names."""
-        return self._config.get('codespace_names', [])
+        return self._data.codespace_names
+
 
 def create_example_config(config_file: Path) -> None:
-    """
-    Create an example configuration file with comments.
-
-    Args:
-        config_file: Path to create example config file
-
-    Example:
-        >>> from pathlib import Path
-        >>> create_example_config(Path('config.example.yaml'))
-    """
+    """Create an example configuration file with comments and profiles."""
     example = """# cs-proxy configuration
 # Copy to ~/.config/cs-proxy/config.yaml
 
@@ -321,40 +298,48 @@ def create_example_config(config_file: Path) -> None:
 # Proxy Settings
 # =============================================================================
 
-# SOCKS5 proxy port (default: 1080)
 socks_port: 1080
-
-# HTTP proxy port (default: 8080)
 http_proxy_port: 8080
+num_proxies: 1
 
 # =============================================================================
 # Codespace Settings
 # =============================================================================
 
-# Default Codespace name (leave empty to select interactively)
 codespace_name: ""
+locations: []
 
 # =============================================================================
 # Connection Settings
 # =============================================================================
 
-# Initial reconnection delay in seconds
 reconnect_delay: 5
-
-# Maximum reconnection delay (caps exponential backoff)
 max_reconnect_delay: 300
 
 # =============================================================================
 # Advanced Settings
 # =============================================================================
 
-# Route DNS through proxy
 dns_proxy: false
-
-# Enable verbose logging
 verbose: false
-"""
 
+# =============================================================================
+# Profiles
+# =============================================================================
+#
+# Profiles let you switch between preset configurations:
+#   cs-proxy start --profile redteam
+#
+# profile: ""
+# profiles:
+#   redteam:
+#     num_proxies: 2
+#     locations: [WestEurope, EastUs]
+#     socks_port: 1080
+#   stealth:
+#     dns_proxy: true
+#     verbose: true
+"""
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.write_text(example)
     get_logger().info(f"Created example config: {config_file}")

--- a/csproxy/wg_constants.py
+++ b/csproxy/wg_constants.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""
+Shared WireGuard constants to avoid duplication across modules.
+
+All WireGuard-related modules should import from here instead of
+redefining defaults locally.
+"""
+
+import os
+
+WG_INTERFACE = os.environ.get("WG_INTERFACE", "cswg0")
+WG_PORT = int(os.environ.get("WG_PORT", "51820"))
+WG_LOCAL_IP = os.environ.get("WG_LOCAL_IP", "10.99.99.2/24")
+WG_REMOTE_IP = os.environ.get("WG_REMOTE_IP", "10.99.99.1/24")
+WG_NETWORK = os.environ.get("WG_NETWORK", "10.99.99.0/24")
+TCP_RELAY_PORT = 51821

--- a/csproxy/wg_monitor.py
+++ b/csproxy/wg_monitor.py
@@ -12,6 +12,7 @@ import subprocess
 from typing import Optional
 
 from .utils import get_logger
+from .wg_constants import WG_INTERFACE
 
 # ANSI color codes
 _RED = '\033[31m'
@@ -20,9 +21,6 @@ _YELLOW = '\033[33m'
 _CYAN = '\033[36m'
 _WHITE = '\033[37m'
 _RESET = '\033[0m'
-
-# Default interface (can be overridden via env vars)
-WG_INTERFACE = os.environ.get('WG_INTERFACE', 'cswg0')
 
 
 def _check_root() -> None:

--- a/csproxy/wg_routes.py
+++ b/csproxy/wg_routes.py
@@ -12,21 +12,29 @@ import subprocess
 from pathlib import Path
 
 from .utils import Config, get_logger
+from .wg_constants import WG_INTERFACE
 
-# WireGuard defaults (can be overridden via env vars)
-WG_INTERFACE = os.environ.get('WG_INTERFACE', 'cswg0')
-
-# GitHub/Azure IP ranges to bypass when routing all traffic through tunnel
+# GitHub/Azure IP ranges to bypass when routing all traffic through tunnel.
+# These keep the SSH tunnel and gh CLI alive when route_all() is active.
+# NOTE: Azure ranges change frequently. If SSH drops after route_all(),
+# add your specific region CIDR here.
 _BYPASS_ROUTES = [
-    '140.82.112.0/20',  # GitHub
-    '192.30.252.0/22',  # GitHub
-    '185.199.108.0/22', # GitHub
-    '20.0.0.0/8',       # Azure
-    '52.0.0.0/8',       # Azure
-    '51.0.0.0/8',       # Azure
-    '13.0.0.0/8',       # Azure
-    '40.0.0.0/8',       # Azure
-    '104.0.0.0/8',      # Azure
+    # GitHub (well-documented, stable)
+    '140.82.112.0/20',   # GitHub web/API
+    '192.30.252.0/22',   # GitHub pages
+    '185.199.108.0/22',  # GitHub pages
+    # Azure (narrowed from /8 to /16 for common datacenter regions)
+    '20.37.0.0/16',      # Azure East US
+    '20.38.0.0/16',      # Azure East US 2
+    '20.42.0.0/16',      # Azure West Europe
+    '20.43.0.0/16',      # Azure North Europe
+    '20.195.0.0/16',     # Azure Southeast Asia
+    '52.96.0.0/16',      # Azure West US 2
+    '52.136.0.0/16',     # Azure West Central US
+    '52.147.0.0/16',     # Azure East US
+    '52.165.0.0/16',     # Azure East US 2
+    '52.166.0.0/16',     # Azure Central US
+    '52.239.0.0/16',     # Azure North Central US
 ]
 
 

--- a/csproxy/wg_setup.py
+++ b/csproxy/wg_setup.py
@@ -7,6 +7,7 @@ Extracted from wireguard.py for modularity.
 """
 
 import os
+import shlex
 import subprocess
 import time
 from datetime import datetime
@@ -60,7 +61,8 @@ def generate_keys(wg_dir: Path) -> None:
     """
     Generate local and remote WireGuard keypairs if they don't exist.
 
-    Equivalent to generate_keys() in cs-wg.sh.
+    Keys are stored as plain text files with 0o600 permissions.
+    For production use, consider encrypting the key directory at rest.
     """
     logger = get_logger()
 
@@ -213,12 +215,13 @@ def ensure_codespace_running(cs_name: str, gh: GitHubManager,
 # Configuration Generation
 # =============================================================================
 
-# Default constants (imported by wireguard.py, used as defaults here)
-_WG_INTERFACE = os.environ.get('WG_INTERFACE', 'cswg0')
-_WG_PORT = int(os.environ.get('WG_PORT', '51820'))
-_WG_LOCAL_IP = os.environ.get('WG_LOCAL_IP', '10.99.99.2/24')
-_WG_REMOTE_IP = os.environ.get('WG_REMOTE_IP', '10.99.99.1/24')
-_WG_NETWORK = os.environ.get('WG_NETWORK', '10.99.99.0/24')
+from .wg_constants import (
+    WG_INTERFACE as _WG_INTERFACE,
+    WG_PORT as _WG_PORT,
+    WG_LOCAL_IP as _WG_LOCAL_IP,
+    WG_REMOTE_IP as _WG_REMOTE_IP,
+    WG_NETWORK as _WG_NETWORK,
+)
 
 
 def generate_local_config(wg_dir: Path, interface: str = _WG_INTERFACE,

--- a/csproxy/wireguard.py
+++ b/csproxy/wireguard.py
@@ -8,6 +8,8 @@ enabling full transparent proxying of all traffic.
 
 import os
 import re
+import shlex
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -31,13 +33,14 @@ from .wg_setup import (  # noqa: F401
 
 VERSION = "1.0.0"
 
-# WireGuard defaults (can be overridden via env vars)
-WG_INTERFACE = os.environ.get('WG_INTERFACE', 'cswg0')
-WG_PORT = int(os.environ.get('WG_PORT', '51820'))
-WG_LOCAL_IP = os.environ.get('WG_LOCAL_IP', '10.99.99.2/24')
-WG_REMOTE_IP = os.environ.get('WG_REMOTE_IP', '10.99.99.1/24')
-WG_NETWORK = os.environ.get('WG_NETWORK', '10.99.99.0/24')
-TCP_RELAY_PORT = 51821
+from .wg_constants import (
+    WG_INTERFACE,
+    WG_PORT,
+    WG_LOCAL_IP,
+    WG_REMOTE_IP,
+    WG_NETWORK,
+    TCP_RELAY_PORT,
+)
 
 
 def start_tunnel(config: Config, gh: GitHubManager) -> None:
@@ -90,8 +93,9 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     script = _build_remote_setup_script(wg_dir)
 
     # Upload setup script via stdin
+    setup_path = '/tmp/setup_wg.sh'
     gh_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
-               'cat > /tmp/setup_wg.sh && chmod +x /tmp/setup_wg.sh']
+               f'cat > {shlex.quote(setup_path)} && chmod +x {shlex.quote(setup_path)}']
     if sudo_user and os.geteuid() == 0:
         gh_cmd = ['sudo', '-u', sudo_user] + gh_cmd
 
@@ -100,7 +104,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
         raise RuntimeError(f"Failed to copy setup script to codespace: "
                            f"{result.stderr.decode().strip()}")
 
-    run_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--', '/tmp/setup_wg.sh']
+    run_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--', setup_path]
     if sudo_user and os.geteuid() == 0:
         run_cmd = ['sudo', '-u', sudo_user] + run_cmd
 
@@ -108,19 +112,27 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     if result.returncode != 0:
         raise RuntimeError("Failed to run WireGuard setup in codespace")
 
+    # Wipe the setup script immediately after execution to avoid leaving
+    # private keys on the Codespace filesystem.
+    wipe_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
+                f'shred -u {shlex.quote(setup_path)} 2>/dev/null || rm -f {shlex.quote(setup_path)}']
+    if sudo_user and os.geteuid() == 0:
+        wipe_cmd = ['sudo', '-u', sudo_user] + wipe_cmd
+    subprocess.run(wipe_cmd, capture_output=True)
+
     time.sleep(2)
 
     # Phase 4: SSH tunnel for UDP relay
     logger.info("Setting up SSH tunnel for UDP relay...")
 
     # Kill any existing local relay processes
-    subprocess.run(['pkill', '-f', f'socat.*UDP.*{WG_PORT}'], capture_output=True)
-    subprocess.run(['pkill', '-f', f'socat.*{TCP_RELAY_PORT}'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
 
     # Verify remote socat is running
     logger.info("Verifying remote relay...")
     verify_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
-                  f"pgrep -f 'socat.*TCP-LISTEN.*{TCP_RELAY_PORT}' > /dev/null && echo 'relay running'"]
+                  f"pgrep -f 'socat.*TCP-LISTEN.*{shlex.quote(str(TCP_RELAY_PORT))}' > /dev/null && echo 'relay running'"]
     if sudo_user and os.geteuid() == 0:
         verify_cmd = ['sudo', '-u', sudo_user] + verify_cmd
 
@@ -130,8 +142,8 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     else:
         logger.warning("Remote socat may not be running, attempting to start...")
         start_socat_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
-                           f'nohup socat TCP-LISTEN:{TCP_RELAY_PORT},reuseaddr,fork '
-                           f'UDP:127.0.0.1:{WG_PORT} > /tmp/socat_relay.log 2>&1 &']
+                           f'nohup socat TCP-LISTEN:{shlex.quote(str(TCP_RELAY_PORT))},reuseaddr,fork '
+                           f'UDP:127.0.0.1:{shlex.quote(str(WG_PORT))} > /tmp/socat_relay.log 2>&1 &']
         if sudo_user and os.geteuid() == 0:
             start_socat_cmd = ['sudo', '-u', sudo_user] + start_socat_cmd
         subprocess.run(start_socat_cmd, capture_output=True)
@@ -150,7 +162,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
         print("The SSH tunnel must be started as your regular user (not root).")
         print("Please run this in another terminal:")
         print()
-        print(f"  gh codespace ssh -c {cs_name} -- "
+        print(f"  gh codespace ssh -c {shlex.quote(cs_name)} -- "
               f"-T -L 127.0.0.1:{TCP_RELAY_PORT}:127.0.0.1:{TCP_RELAY_PORT} -N &")
         print()
         input("Then press Enter to continue...")
@@ -265,13 +277,14 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
     if socat_pid_file.exists():
         try:
             pid = int(socat_pid_file.read_text().strip())
-            os.kill(pid, 15)  # SIGTERM
+            os.kill(pid, 0)  # validate PID exists before signaling
+            os.kill(pid, signal.SIGTERM)
         except (OSError, ValueError):
             pass
         socat_pid_file.unlink(missing_ok=True)
-    subprocess.run(['pkill', '-f', f'socat.*UDP.*{WG_PORT}'], capture_output=True)
-    subprocess.run(['pkill', '-f', 'socat.*51820'], capture_output=True)
-    subprocess.run(['pkill', '-f', 'socat.*51821'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
 
     # Stop SSH tunnel
     logger.info("Stopping SSH tunnel...")
@@ -279,20 +292,21 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
     if ssh_pid_file.exists():
         try:
             pid = int(ssh_pid_file.read_text().strip())
-            os.kill(pid, 15)
+            os.kill(pid, 0)  # validate PID exists before signaling
+            os.kill(pid, signal.SIGTERM)
         except (OSError, ValueError):
             pass
         ssh_pid_file.unlink(missing_ok=True)
     subprocess.run(['pkill', '-f', 'gh.*codespace.*ssh.*-L'], capture_output=True)
-    subprocess.run(['pkill', '-f', 'ssh.*51821:127.0.0.1'], capture_output=True)
-    subprocess.run(['fuser', '-k', '51821/tcp'], capture_output=True)
+    subprocess.run(['pkill', '-f', f'ssh.*{shlex.quote(str(TCP_RELAY_PORT))}:127.0.0.1'], capture_output=True)
+    subprocess.run(['fuser', '-k', f'{shlex.quote(str(TCP_RELAY_PORT))}/tcp'], capture_output=True)
 
     # Stop remote WireGuard if codespace accessible
     if cs_name:
         logger.info(f"Cleaning up codespace ({cs_name})...")
         cleanup_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
-                       'sudo wg-quick down wg0 2>/dev/null || true; '
-                       'pkill -f \'socat.*TCP-LISTEN.*51821\' 2>/dev/null || true']
+                       f'sudo wg-quick down wg0 2>/dev/null || true; '
+                       f'pkill -f socat.*TCP-LISTEN.*{shlex.quote(str(TCP_RELAY_PORT))} 2>/dev/null || true']
         if sudo_user and os.geteuid() == 0:
             cleanup_cmd = ['sudo', '-u', sudo_user] + cleanup_cmd
         subprocess.run(cleanup_cmd, capture_output=True)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,18 +16,30 @@ Fluffy-Barnacle is an operator-focused toolkit that turns GitHub Codespaces into
 
 | Tool | Description |
 |------|-------------|
-| **[cs-proxy](user-guide/command-reference/cs-proxy.md)** | SOCKS5 and HTTP proxy via SSH tunnel with auto-reconnect and Burp Suite integration |
+| **[cs-proxy](user-guide/command-reference/cs-proxy.md)** | SOCKS5 and HTTP proxy via SSH tunnel with auto-reconnect, circuit breaker, and Burp Suite integration |
 | **[cs-serve](user-guide/command-reference/cs-serve.md)** | Instant public HTTPS file hosting, redirect servers, custom HTTP responses, and data capture via `*.app.github.dev` |
 | **[cs-wg](user-guide/command-reference/cs-wg.md)** | Full WireGuard VPN tunnel with route management and traffic monitoring |
-| **[cs-tools](user-guide/command-reference/cs-tools.md)** | Drop-in wrappers for nmap, ffuf, httpx, nuclei, sqlmap with automatic SOCKS5 proxy arguments |
+| **[cs-tools](user-guide/command-reference/cs-tools.md)** | Drop-in wrappers for nmap, ffuf, httpx, nuclei, sqlmap with automatic SOCKS5 proxy arguments and smart tunnel rotation |
 
 Each tool can be used from the CLI or imported directly as a [Python library](development/python-api.md).
+
+## What's New
+
+- **Smart tunnel rotation** — `cs-tools` automatically distributes traffic across healthy tunnels
+- **`cs-proxy check`** — One-command diagnostics for setup, auth, ports, and state health
+- **`--dry-run`** — Preview what `start`/`stop` would do without making changes
+- **Profiles** — Switch between preset configs (e.g. `redteam` / `stealth`) without editing files
+- **Circuit breaker** — Tunnels that fail health checks 3× in a row are automatically marked dead
+- **Shell completion** — Bash and zsh completion via `cs-proxy completion bash`
+- **PAC file generation** — `cs-proxy pac` outputs a Proxy Auto-Config script for browser routing
+- **Status watch mode** — `cs-proxy status --watch` auto-refreshes every 2 seconds
 
 ## Getting Started
 
 ```bash
 pip install -e .
 gh auth login
+cs-proxy check
 cs-proxy start
 cs-tools ipcheck
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ Get cs-proxy running in under a minute.
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
 - `ssh` and `curl` available
 
@@ -22,6 +22,14 @@ pip install -e .
 gh auth login
 ```
 
+## Verify Your Setup
+
+```bash
+cs-proxy check
+```
+
+This diagnoses your environment: `gh` auth, SSH keys, port availability, config, and state file health.
+
 ## Start a Proxy
 
 ```bash
@@ -32,7 +40,7 @@ This will:
 
 1. Select an existing Codespace (or create one interactively)
 2. Start an SSH tunnel with SOCKS5 forwarding on `127.0.0.1:1080`
-3. Run in the background with automatic reconnection
+3. Run in the background with automatic reconnection and circuit-breaker protection
 
 ## Verify
 
@@ -50,6 +58,13 @@ This compares your direct IP with the proxied IP to confirm traffic is routing t
 cs-tools pcurl https://ifconfig.me
 cs-tools pnmap -p 80,443 target.com
 cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
+```
+
+### Monitor tunnel health
+
+```bash
+cs-proxy status              # one-shot status
+cs-proxy status --watch      # auto-refresh every 2 seconds
 ```
 
 ### Serve files publicly
@@ -79,6 +94,15 @@ cs-proxy status     # health + exit IP per tunnel
 cs-proxy ssh        # numbered menu to pick which codespace to shell into
 ```
 
+## Dry-Run Mode
+
+Preview actions without making changes:
+
+```bash
+cs-proxy --dry-run start     # show what would start
+cs-proxy --dry-run stop      # show what would stop
+```
+
 ## Stop
 
 ```bash
@@ -90,6 +114,6 @@ cs-proxy delete        # permanently delete codespace(s)
 ## Next Steps
 
 - [Installation Guide](user-guide/installation.md) -- platform-specific setup and troubleshooting
-- [Configuration](user-guide/configuration.md) -- customize ports, codespace, and behavior
+- [Configuration](user-guide/configuration.md) -- customize ports, codespace, profiles, and behavior
 - [Command Reference](user-guide/command-reference/index.md) -- full list of commands
 - [Use Cases](use-cases/index.md) -- real-world scenarios and workflows

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,8 +107,9 @@ cs-proxy --dry-run stop      # show what would stop
 
 ```bash
 cs-proxy stop          # stop all proxy tunnels
-cs-proxy down          # stop tunnels + shut down all managed codespaces
-cs-proxy delete        # permanently delete codespace(s)
+cs-proxy teardown      # stop tunnels + shut down codespaces (storage preserved)
+cs-proxy down          # stop tunnels + permanently delete codespaces
+cs-proxy delete        # interactively delete specific codespace(s)
 ```
 
 ## Next Steps

--- a/docs/use-cases/proxy-rotation.md
+++ b/docs/use-cases/proxy-rotation.md
@@ -2,6 +2,20 @@
 
 Rotate your egress IP by cycling GitHub Codespaces. Each Codespace gets a fresh IP from GitHub's Azure infrastructure.
 
+## Smart Tunnel Rotation
+
+When you have multiple tunnels running, `cs-tools` automatically picks a healthy tunnel from `state.json`. If one tunnel goes down, traffic is routed through another without manual intervention.
+
+```bash
+cs-proxy -n 2 start -l WestEurope -l EastUs
+
+# cs-tools will automatically distribute traffic across healthy tunnels
+cs-tools pnmap -p 80,443 target.com
+cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
+```
+
+The rotation is random across healthy tunnels. If no healthy tunnels exist, tools fall back to the configured `socks_port`.
+
 ## Two Simultaneous Proxies
 
 Run two independent tunnels at once, each with a different exit IP:
@@ -66,10 +80,20 @@ for i in range(5):
     time.sleep(5)
 ```
 
+## Circuit Breaker
+
+Tunnels have built-in circuit-breaker protection. If a tunnel fails 3 consecutive health checks (e.g. the Codespace was deleted or the SSH relay is down), it is automatically marked as `dead` and stops retrying. This prevents infinite reconnection loops.
+
+Reset a dead tunnel with:
+
+```bash
+cs-proxy restart
+```
+
 ## Tips
 
 - Codespace creation takes 30-60 seconds. Factor this into your rotation timing.
 - GitHub's free tier includes 120 core-hours/month. A 2-core Codespace gives you 60 hours.
-- The free tier allows a maximum of 2 codespaces. Use `-n 2` to pre-create both.
+- The free tier allows multiple codespaces. Use `-n 2` to pre-create both.
 - Codespaces that sit idle are automatically stopped after 30 minutes, saving billing.
 - Use `cs-proxy teardown` (not just `stop`) to fully delete and free resources.

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -13,7 +13,7 @@ cs-proxy [options] <command> [args]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `-p`, `--port` | SOCKS5 proxy port | `1080` |
-| `-n`, `--num-proxies` | Number of codespaces/tunnels (1-5); each gets its own port | `1` |
+| `-n`, `--num-proxies` | Number of codespaces/tunnels (1-2 on free tier); each gets its own port | `1` |
 | `-c`, `--codespace` | Codespace name | auto-select |
 | `-l`, `--location` | Region for new Codespace: `EastUs`, `WestUs2`, `WestEurope`, `SouthEastAsia`. Repeat for multiple: `-l WestEurope -l EastUs` | none |
 | `-v`, `--verbose` | Verbose output | off |

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -5,8 +5,19 @@ SOCKS5 and HTTP proxy management via SSH tunnel to a GitHub Codespace.
 ## Usage
 
 ```
-cs-proxy <command> [options]
+cs-proxy [options] <command> [args]
 ```
+
+## Global Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-p`, `--port` | SOCKS5 proxy port | `1080` |
+| `-n`, `--num-proxies` | Number of codespaces/tunnels (1-5); each gets its own port | `1` |
+| `-c`, `--codespace` | Codespace name | auto-select |
+| `-l`, `--location` | Region for new Codespace: `EastUs`, `WestUs2`, `WestEurope`, `SouthEastAsia`. Repeat for multiple: `-l WestEurope -l EastUs` | none |
+| `-v`, `--verbose` | Verbose output | off |
+| `--dry-run` | Show what would happen without making changes | off |
 
 ## Commands
 
@@ -22,11 +33,14 @@ cs-proxy start -c my-codespace-name          # use a specific codespace
 cs-proxy start -p 9050                       # use a non-default port
 cs-proxy -n 2 start                          # two codespaces, two tunnels (1080 + 1081)
 cs-proxy -n 2 start -l WestEurope -l EastUs  # pin each to a specific region
+cs-proxy --dry-run start                     # preview what would happen
 ```
 
-Starts an SSH tunnel with SOCKS5 dynamic port forwarding on `127.0.0.1:<port>`. The tunnel runs in the background with automatic reconnection using exponential backoff.
+Starts an SSH tunnel with SOCKS5 dynamic port forwarding on `127.0.0.1:<port>`. The tunnel runs in the background with automatic reconnection using exponential backoff and jitter.
 
 When `-n 2` is used, a second codespace is created (or reused) and a second independent tunnel is started on the next port (`socks_port + 1`). Each tunnel has a different exit IP. Use `-l` once per codespace to pin each to a region: `EastUs`, `WestUs2`, `WestEurope`, `SouthEastAsia`.
+
+**Circuit breaker:** If a tunnel fails 3 consecutive health checks, it is automatically marked as `dead` and stops retrying. Use `cs-proxy restart` to reset it.
 
 #### `stop`
 
@@ -34,6 +48,7 @@ Stop the proxy tunnel and HTTP proxy.
 
 ```bash
 cs-proxy stop
+cs-proxy --dry-run stop   # preview what would stop
 ```
 
 #### `restart`
@@ -50,9 +65,31 @@ Show tunnel status, Codespace state, and exit IP.
 
 ```bash
 cs-proxy status
+cs-proxy status --watch   # auto-refresh every 2 seconds
 ```
 
 When multiple codespaces are tracked, shows each tunnel's port, health, and exit IP side by side.
+
+### Diagnostics
+
+#### `check`
+
+Run diagnostics and report configuration/dependency health.
+
+```bash
+cs-proxy check
+```
+
+Checks:
+
+- `gh` CLI installed and authenticated
+- `ssh`, `curl`, `proxychains4` installed
+- Config directory and file present
+- SSH key generated
+- SOCKS5/HTTP ports available
+- State file readable
+
+Returns exit code `0` if all checks pass, `1` if any issues are found.
 
 ### HTTP Proxy
 
@@ -86,12 +123,31 @@ Print Burp Suite upstream proxy configuration.
 cs-proxy burp
 ```
 
+#### `pac`
+
+Generate a Proxy Auto-Config (PAC) file for browser routing.
+
+```bash
+cs-proxy pac > ~/.config/cs-proxy/proxy.pac
+```
+
+The PAC script routes local addresses directly and sends everything else through the SOCKS5 proxy. Point your browser to `file:///Users/you/.config/cs-proxy/proxy.pac`.
+
 #### `proxychains`
 
 Generate a proxychains4 configuration file.
 
 ```bash
 cs-proxy proxychains
+```
+
+#### `completion`
+
+Generate shell completion scripts.
+
+```bash
+cs-proxy completion bash   # bash completion
+cs-proxy completion zsh    # zsh completion
 ```
 
 #### `set`
@@ -105,7 +161,7 @@ cs-proxy set codespace_name my-codespace
 
 #### `config`
 
-Manage configuration files.
+Open the configuration file in your `$EDITOR`.
 
 ```bash
 cs-proxy config
@@ -189,14 +245,5 @@ Show tunnel logs.
 
 ```bash
 cs-proxy logs
+cs-proxy logs 100     # last 100 lines
 ```
-
-## Options
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-p`, `--port` | SOCKS5 proxy port | `1080` |
-| `-n`, `--num-proxies` | Number of codespaces/tunnels (max 2); each gets its own port | `1` |
-| `-c`, `--codespace` | Codespace name | auto-select |
-| `-l`, `--location` | Region for new Codespace: `EastUs`, `WestUs2`, `WestEurope`, `SouthEastAsia`. Repeat for multiple: `-l WestEurope -l EastUs` | none |
-| `-v`, `--verbose` | Verbose output | off |

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -185,14 +185,23 @@ Create a new Codespace interactively.
 cs-proxy create
 ```
 
-#### `teardown` / `down`
+#### `teardown`
 
 Stop the proxy tunnel(s) and shut down all managed Codespaces (compute stops, storage is preserved — no billing).
 
 ```bash
 cs-proxy teardown     # stops all tunnels and all tracked codespaces
-cs-proxy down         # alias
 ```
+
+#### `down`
+
+Stop the proxy tunnel(s), shut down, and **permanently delete** all managed Codespaces.
+
+```bash
+cs-proxy down         # stops tunnels, then prompts to confirm deletion
+```
+
+This is the "nuclear option" for cleaning up after a session. It stops tunnels, stops codespaces, then asks for confirmation before permanently deleting them.
 
 #### `name`
 

--- a/docs/user-guide/command-reference/cs-tools.md
+++ b/docs/user-guide/command-reference/cs-tools.md
@@ -2,7 +2,7 @@
 
 Drop-in wrappers for common security tools that automatically apply SOCKS5 proxy arguments.
 
-Each wrapper checks that cs-proxy is running before executing and exits with a warning if the proxy is down.
+Each wrapper checks that cs-proxy is running before executing and exits with a warning if the proxy is down. When multiple tunnels are active, `cs-tools` automatically rotates across healthy tunnels.
 
 ## Usage
 
@@ -31,7 +31,7 @@ cs-tools pcurl https://ifconfig.me
 cs-tools pcurl -X POST -d '{"test":true}' https://target.com/api
 ```
 
-Automatically adds `--socks5-hostname 127.0.0.1:<port>`.
+Automatically adds `--socks5-hostname 127.0.0.1:<port>`. If multiple tunnels are healthy, a random healthy port is used.
 
 ### `pwget`
 
@@ -115,6 +115,19 @@ cs-tools pportscan 10.0.0.1
 ```
 
 Default ports: `21,22,23,25,80,443,445,3306,3389,8080,8443`
+
+## Smart Tunnel Rotation
+
+When multiple tunnels are active, `cs-tools` wrappers read `state.json` and pick a random healthy tunnel port. This means:
+
+```bash
+cs-proxy -n 2 start -l WestEurope -l EastUs
+# Each cs-tools call may use a different exit IP automatically
+cs-tools pnmap -p 80,443 target.com
+cs-tools phttpx -l hosts.txt
+```
+
+If no healthy tunnels exist, tools fall back to the default `socks_port`.
 
 ## Default Wordlists
 

--- a/docs/user-guide/command-reference/index.md
+++ b/docs/user-guide/command-reference/index.md
@@ -6,10 +6,10 @@ cs-proxy provides four CLI tools, each with its own set of commands.
 
 | Tool | Entry Point | Purpose |
 |------|-------------|---------|
-| [cs-proxy](cs-proxy.md) | `cs-proxy <command>` | SOCKS5/HTTP proxy management |
+| [cs-proxy](cs-proxy.md) | `cs-proxy [options] <command>` | SOCKS5/HTTP proxy management with circuit breaker, dry-run, and diagnostics |
 | [cs-serve](cs-serve.md) | `cs-serve <command>` | Public file hosting and HTTP servers |
 | [cs-wg](cs-wg.md) | `sudo cs-wg <command>` | WireGuard VPN tunnel management |
-| [cs-tools](cs-tools.md) | `cs-tools <tool> [args]` | Proxied security tool wrappers |
+| [cs-tools](cs-tools.md) | `cs-tools <tool> [args]` | Proxied security tool wrappers with smart tunnel rotation |
 
 ## Global Options
 
@@ -20,12 +20,14 @@ All tools support these flags:
 | `-c`, `--codespace` | Specify Codespace name (skip interactive selection) |
 | `-v`, `--verbose` | Enable debug output |
 | `-h`, `--help` | Show help text |
+| `--dry-run` | Show what would happen without making changes (`cs-proxy` only) |
 
 ## Common Workflows
 
 ### Start a proxy session
 
 ```bash
+cs-proxy check          # verify setup first
 cs-proxy start
 cs-proxy status
 cs-tools ipcheck
@@ -51,5 +53,5 @@ sudo cs-wg status
 ```bash
 cs-proxy start
 cs-tools pnmap -p 80,443,8080 target.com
-cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
+cs-tools pffuf -u https://target.com/FUZZ -w list.txt
 ```

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-cs-proxy uses a YAML configuration file with environment variable overrides.
+cs-proxy uses a YAML configuration file with environment variable overrides and profile support.
 
 ## Config File
 
@@ -10,7 +10,7 @@ cs-proxy uses a YAML configuration file with environment variable overrides.
 # Proxy settings
 socks_port: 1080
 http_proxy_port: 8080
-num_proxies: 1              # 1-2; each codespace gets its own tunnel on consecutive ports
+num_proxies: 1              # 1-5; each codespace gets its own tunnel on consecutive ports
 
 # Codespace settings
 codespace_name: ""          # blank = interactive selection
@@ -19,12 +19,33 @@ locations: []               # e.g. [WestEurope, EastUs] — one region per codes
 
 # Connection settings
 reconnect_delay: 5          # initial reconnect delay (seconds)
-max_reconnect_delay: 300    # max delay with exponential backoff
+max_reconnect_delay: 300    # max delay with exponential backoff + jitter
 
 # Advanced
 dns_proxy: false
 verbose: false
+
+# Profiles — switch between presets without editing files
+profile: ""                 # active profile name (must match a key below)
+profiles:
+  redteam:
+    num_proxies: 2
+    locations: [WestEurope, EastUs]
+  stealth:
+    dns_proxy: true
+    verbose: true
 ```
+
+### Validation
+
+The config is validated on load and when setting values:
+
+- `socks_port` and `http_proxy_port` must be between `1024` and `65535`
+- `num_proxies` must be between `1` and `5`
+- `reconnect_delay` must be `>= 1`
+- `max_reconnect_delay` must be `>= reconnect_delay`
+
+Invalid values raise an error immediately so bad configs are caught at startup.
 
 ### Create a Config File
 
@@ -42,6 +63,23 @@ from pathlib import Path
 create_example_config(Path.home() / '.config/cs-proxy/config.yaml')
 ```
 
+## Profiles
+
+Profiles let you switch between preset configurations from the command line:
+
+```yaml
+profile: "redteam"
+profiles:
+  redteam:
+    num_proxies: 2
+    locations: [WestEurope, EastUs]
+  stealth:
+    dns_proxy: true
+    verbose: true
+```
+
+When `profile` is set to a key that exists in `profiles`, those values override the top-level defaults. Profile values are merged — keys not specified in the profile keep their default values.
+
 ## Environment Variables
 
 All settings can be overridden via environment variables:
@@ -50,13 +88,13 @@ All settings can be overridden via environment variables:
 |----------|-----------|---------|-------------|
 | `SOCKS_PORT` | `socks_port` | `1080` | SOCKS5 proxy listen port |
 | `HTTP_PROXY_PORT` | `http_proxy_port` | `8080` | HTTP proxy listen port |
-| `NUM_PROXIES` | `num_proxies` | `1` | Number of codespaces/tunnels (max 2) |
+| `NUM_PROXIES` | `num_proxies` | `1` | Number of codespaces/tunnels (1-5) |
 | `CODESPACE_NAME` | `codespace_name` | `""` | Target Codespace name |
 | `LOCATIONS` | `locations` | `[]` | Comma-separated regions, e.g. `WestEurope,EastUs` |
 | `RECONNECT_DELAY` | `reconnect_delay` | `5` | Initial reconnect delay (s) |
 | `MAX_RECONNECT_DELAY` | `max_reconnect_delay` | `300` | Max reconnect delay (s) |
-| `DNS_PROXY` | `dns_proxy` | `false` | Route DNS through proxy |
-| `VERBOSE` | `verbose` | `false` | Enable debug logging |
+| `DNS_PROXY` | `dns_proxy` | `false` | Route DNS through proxy (`true`/`1`/`yes`) |
+| `VERBOSE` | `verbose` | `false` | Enable debug logging (`true`/`1`/`yes`) |
 
 ### Additional Environment Variables
 
@@ -76,8 +114,9 @@ Settings are resolved in this order (highest wins):
 
 1. Command-line arguments (`-p`, `-c`, etc.)
 2. Environment variables
-3. Config file (`~/.config/cs-proxy/config.yaml`)
-4. Built-in defaults
+3. Active profile values (if `profile:` is set)
+4. Config file (`~/.config/cs-proxy/config.yaml`)
+5. Built-in defaults
 
 ## GitHub Authentication
 
@@ -101,3 +140,9 @@ chmod 600 ~/.config/cs-proxy/gh_token
 ```
 
 The token needs the `codespace` scope.
+
+## Deprecated Keys
+
+The following keys are deprecated and will be ignored with a warning:
+
+- `chain` — no longer used; remove from your config file

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -10,7 +10,7 @@ cs-proxy uses a YAML configuration file with environment variable overrides and 
 # Proxy settings
 socks_port: 1080
 http_proxy_port: 8080
-num_proxies: 1              # 1-5; each codespace gets its own tunnel on consecutive ports
+num_proxies: 1              # 1-2 on free tier; each gets its own tunnel on consecutive ports
 
 # Codespace settings
 codespace_name: ""          # blank = interactive selection
@@ -88,7 +88,7 @@ All settings can be overridden via environment variables:
 |----------|-----------|---------|-------------|
 | `SOCKS_PORT` | `socks_port` | `1080` | SOCKS5 proxy listen port |
 | `HTTP_PROXY_PORT` | `http_proxy_port` | `8080` | HTTP proxy listen port |
-| `NUM_PROXIES` | `num_proxies` | `1` | Number of codespaces/tunnels (1-5) |
+| `NUM_PROXIES` | `num_proxies` | `1` | Number of codespaces/tunnels (1-2 on free tier) |
 | `CODESPACE_NAME` | `codespace_name` | `""` | Target Codespace name |
 | `LOCATIONS` | `locations` | `[]` | Comma-separated regions, e.g. `WestEurope,EastUs` |
 | `RECONNECT_DELAY` | `reconnect_delay` | `5` | Initial reconnect delay (s) |

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -107,6 +107,9 @@ cs-serve --help
 cs-wg --help
 cs-tools --help
 
+# Run diagnostics
+cs-proxy check
+
 # Run the test suite
 python -m pytest tests/ -v
 ```

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -181,3 +181,19 @@ def test_get_exit_ip_uses_socks5_hostname():
     assert '--socks5-hostname' in args
     assert '--socks5' not in args
     assert ip == '1.2.3.4'
+
+
+def test_check_proxy_uses_socks5_hostname():
+    """check_proxy() must use --socks5-hostname to resolve DNS via proxy (issue #5)."""
+    from csproxy.tools import check_proxy
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        result = check_proxy()
+
+    args = mock_run.call_args[0][0]
+    assert '--socks5-hostname' in args
+    assert '--socks5' not in args
+    assert result is True

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -39,7 +39,7 @@ def test_proxy_module_exports():
         'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
         'config', 'logs', 'split', 'ssh', 'run', 'name',
         'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
-        'pac', 'completion', 'help',
+        'pac', 'completion', 'check', 'help',
     }
     assert expected_commands <= set(COMMANDS.keys())
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -38,7 +38,8 @@ def test_proxy_module_exports():
         'start', 'stop', 'restart', 'status', 'list', 'create',
         'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
         'config', 'logs', 'split', 'ssh', 'run', 'name',
-        'teardown', 'down', 'delete', 'rm', 'token', 'aliases', 'help',
+        'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
+        'pac', 'completion', 'help',
     }
     assert expected_commands <= set(COMMANDS.keys())
 

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -206,7 +206,8 @@ def test_proxy_module():
             'start', 'stop', 'restart', 'status', 'list', 'create',
             'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
             'config', 'logs', 'split', 'ssh', 'run', 'name',
-            'teardown', 'down', 'delete', 'rm', 'token', 'help',
+            'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
+            'pac', 'completion', 'help',
         }
         registered = set(COMMANDS.keys())
         missing = expected_commands - registered

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -207,7 +207,7 @@ def test_proxy_module():
             'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
             'config', 'logs', 'split', 'ssh', 'run', 'name',
             'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
-            'pac', 'completion', 'help',
+            'pac', 'completion', 'check', 'help',
         }
         registered = set(COMMANDS.keys())
         missing = expected_commands - registered

--- a/tests/test_phase2_features.py
+++ b/tests/test_phase2_features.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Phase 2 feature tests - Config dataclass, profiles, rotation, completion, PAC, state.
+
+These tests verify the UX improvements added in Phase 2:
+- Dataclass-based Config with validation and profiles
+- Smart proxy rotation via _get_proxy_port
+- Shell completion generator
+- PAC command output
+- State module basics
+- New CLI commands (pac, completion)
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+# =============================================================================
+# Config dataclass + validation + profiles
+# =============================================================================
+
+
+def test_config_data_validation_rejects_low_port():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="socks_port must be 1024-65535"):
+        _ConfigData(socks_port=80)
+
+
+def test_config_data_validation_rejects_high_port():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="socks_port must be 1024-65535"):
+        _ConfigData(socks_port=70000)
+
+
+def test_config_data_validation_rejects_too_many_proxies():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="num_proxies must be 1-5"):
+        _ConfigData(num_proxies=10)
+
+
+def test_config_data_validation_rejects_zero_proxies():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="num_proxies must be 1-5"):
+        _ConfigData(num_proxies=0)
+
+
+def test_config_data_validation_rejects_bad_delay():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="reconnect_delay must be >= 1"):
+        _ConfigData(reconnect_delay=0)
+
+
+def test_config_data_validation_rejects_inconsistent_max_delay():
+    from csproxy.utils.config import _ConfigData
+    with pytest.raises(ValueError, match="max_reconnect_delay must be >= reconnect_delay"):
+        _ConfigData(reconnect_delay=10, max_reconnect_delay=5)
+
+
+def test_config_data_profile_merge():
+    from csproxy.utils.config import _ConfigData
+    raw = {
+        "profile": "redteam",
+        "profiles": {
+            "redteam": {"socks_port": 9090, "num_proxies": 2},
+            "stealth": {"dns_proxy": True},
+        },
+        "socks_port": 1080,
+        "dns_proxy": False,
+    }
+    cfg = _ConfigData.from_dict(raw)
+    assert cfg.socks_port == 9090
+    assert cfg.num_proxies == 2
+    assert cfg.dns_proxy is False  # not overridden by profile
+
+
+def test_config_data_profile_ignored_when_not_found():
+    from csproxy.utils.config import _ConfigData
+    raw = {"profile": "nonexistent", "socks_port": 1080}
+    cfg = _ConfigData.from_dict(raw)
+    assert cfg.socks_port == 1080
+
+
+def test_config_data_set_field_revalidates():
+    from csproxy.utils.config import _ConfigData
+    cfg = _ConfigData(socks_port=1080)
+    cfg.set_field("socks_port", 9090)
+    assert cfg.socks_port == 9090
+    with pytest.raises(ValueError):
+        cfg.set_field("socks_port", 80)
+
+
+def test_config_data_set_field_rejects_unknown_key():
+    from csproxy.utils.config import _ConfigData
+    cfg = _ConfigData()
+    with pytest.raises(KeyError, match="Unknown config key"):
+        cfg.set_field("nonexistent", 1)
+
+
+def test_config_env_override_socks_port(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    monkeypatch.setenv("SOCKS_PORT", "9999")
+    config = Config(config_dir=tmp_path)
+    assert config.socks_port == 9999
+
+
+def test_config_env_override_locations(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    monkeypatch.setenv("LOCATIONS", "WestEurope,EastUs")
+    config = Config(config_dir=tmp_path)
+    assert config.locations == ["WestEurope", "EastUs"]
+
+
+def test_config_env_override_bool(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    monkeypatch.setenv("DNS_PROXY", "true")
+    config = Config(config_dir=tmp_path)
+    assert config.dns_proxy is True
+
+
+def test_config_save_and_load_preserve_unknown_keys(tmp_path):
+    from csproxy.utils.config import Config
+    config = Config(config_dir=tmp_path)
+    config._extra["custom_key"] = "custom_value"
+    config.save()
+
+    config2 = Config(config_dir=tmp_path)
+    assert config2._extra.get("custom_key") == "custom_value"
+
+
+def test_config_save_and_load_preserve_profiles(tmp_path):
+    from csproxy.utils.config import Config
+    config = Config(config_dir=tmp_path)
+    config.set("profile", "test")
+    config.set("profiles", {"test": {"socks_port": 7777}})
+    config.save()
+
+    config2 = Config(config_dir=tmp_path)
+    assert config2.get("profiles") == {"test": {"socks_port": 7777}}
+
+
+# =============================================================================
+# Proxy rotation
+# =============================================================================
+
+
+def test_get_proxy_port_fallback_when_no_state(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    from csproxy.tools import _get_proxy_port
+    config = Config(config_dir=tmp_path)
+    assert _get_proxy_port(config) == 1080
+
+
+def test_get_proxy_port_uses_healthy_tunnel(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    from csproxy.tools import _get_proxy_port
+    from csproxy.state import State
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1081",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1081,
+        pid=99999,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    port = _get_proxy_port(config)
+    assert port == 1081
+
+
+def test_get_proxy_port_fallback_when_no_healthy_tunnels(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+    from csproxy.tools import _get_proxy_port
+    from csproxy.state import State
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1081",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1081,
+        pid=99999,
+        status="crashed",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    port = _get_proxy_port(config)
+    assert port == 1080  # falls back to config default
+
+
+# =============================================================================
+# Shell completion generator
+# =============================================================================
+
+
+def test_bash_completion_contains_all_commands():
+    from csproxy.completion import generate_completion
+    script = generate_completion("bash")
+    for cmd in ("start", "stop", "status", "pac", "completion", "help"):
+        assert cmd in script, f"Missing command in bash completion: {cmd}"
+    assert "complete -F" in script
+
+
+def test_zsh_completion_contains_all_commands():
+    from csproxy.completion import generate_completion
+    script = generate_completion("zsh")
+    for cmd in ("start", "stop", "status", "pac", "completion", "help"):
+        assert cmd in script, f"Missing command in zsh completion: {cmd}"
+    assert "_describe" in script
+
+
+def test_completion_rejects_unsupported_shell():
+    from csproxy.completion import generate_completion
+    script = generate_completion("fish")
+    assert "Unsupported shell" in script
+
+
+def test_completion_is_case_insensitive():
+    from csproxy.completion import generate_completion
+    assert "complete -F" in generate_completion("BASH")
+    assert "#compdef" in generate_completion("Zsh")
+
+
+# =============================================================================
+# PAC command
+# =============================================================================
+
+
+def test_cmd_pac_contains_socks_port():
+    from csproxy.proxy import cmd_pac
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    import io
+
+    config = Config()
+    gh = GitHubManager()
+    captured = io.StringIO()
+    with patch("sys.stdout", new=captured):
+        result = cmd_pac([], config, gh)
+    assert result == 0
+    output = captured.getvalue()
+    assert "SOCKS5 127.0.0.1:" in output
+    assert "DIRECT" in output
+    assert "function FindProxyForURL" in output
+
+
+def test_cmd_pac_uses_config_port():
+    from csproxy.proxy import cmd_pac
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    import io
+
+    config = Config()
+    config.set("socks_port", 9999)
+    gh = GitHubManager()
+    captured = io.StringIO()
+    with patch("sys.stdout", new=captured):
+        cmd_pac([], config, gh)
+    output = captured.getvalue()
+    assert "127.0.0.1:9999" in output
+
+
+# =============================================================================
+# Completion command
+# =============================================================================
+
+
+def test_cmd_completion_bash():
+    from csproxy.proxy import cmd_completion
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    import io
+
+    config = Config()
+    gh = GitHubManager()
+    captured = io.StringIO()
+    with patch("sys.stdout", new=captured):
+        result = cmd_completion(["bash"], config, gh)
+    assert result == 0
+    assert "complete -F" in captured.getvalue()
+
+
+def test_cmd_completion_unsupported_shell():
+    from csproxy.proxy import cmd_completion
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+
+    config = Config()
+    gh = GitHubManager()
+    result = cmd_completion(["fish"], config, gh)
+    assert result == 1
+
+
+# =============================================================================
+# State module basics
+# =============================================================================
+
+
+def test_state_init_creates_dir(tmp_path):
+    from csproxy.state import State
+    subdir = tmp_path / "state_test"
+    state = State(subdir)
+    assert subdir.exists()
+
+
+def test_state_add_and_get_tunnel(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="starting",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    tunnels = state.get_tunnels(kind="ssh")
+    assert len(tunnels) == 1
+    assert tunnels[0]["port"] == 1080
+
+
+def test_state_remove_tunnel(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="starting",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    state.remove_tunnel(tunnel_id="ssh-1080")
+    assert state.get_tunnels(kind="ssh") == []
+
+
+def test_state_update_tunnel(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="starting",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    state.update_tunnel(1080, status="healthy")
+    t = state.get_tunnel_by_port(1080)
+    assert t["status"] == "healthy"
+
+
+def test_state_reconcile_marks_dead_pid_as_crashed(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=999999,  # non-existent PID
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    crashed = state.reconcile()
+    assert len(crashed) == 1
+    assert crashed[0]["status"] == "crashed"
+
+
+def test_state_record_failure_tracks_failures(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    # max_failures=3, window=600
+    tripped = state.record_failure(1080, max_failures=3, window=600)
+    assert tripped is False
+    t = state.get_tunnel_by_port(1080)
+    assert t["failures"] == 1
+
+
+def test_state_record_failure_trips_circuit_breaker(tmp_path):
+    from csproxy.state import State
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    tripped = state.record_failure(1080, max_failures=2, window=600)
+    assert tripped is False
+    tripped = state.record_failure(1080, max_failures=2, window=600)
+    assert tripped is True
+
+
+# =============================================================================
+# New CLI commands registered
+# =============================================================================
+
+
+def test_pac_command_in_dispatch_table():
+    from csproxy.proxy import COMMANDS
+    assert "pac" in COMMANDS
+    assert callable(COMMANDS["pac"])
+
+
+def test_completion_command_in_dispatch_table():
+    from csproxy.proxy import COMMANDS
+    assert "completion" in COMMANDS
+    assert callable(COMMANDS["completion"])
+
+
+def test_status_watch_flag_dispatches_to_watch_status():
+    from csproxy.proxy import cmd_status
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    from unittest.mock import MagicMock
+
+    config = Config()
+    gh = GitHubManager()
+    with patch("csproxy.display.watch_status") as mock_watch:
+        result = cmd_status(["--watch"], config, gh)
+    assert result == 0
+    mock_watch.assert_called_once()

--- a/tests/test_phase3_hardening.py
+++ b/tests/test_phase3_hardening.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Phase 3 hardening tests — circuit breaker, jitter, dry-run, check, deprecation.
+
+Covers production-readiness fixes:
+- Circuit breaker integration in health_check()
+- Worker reconnect jitter
+- Worker crash stderr surfacing
+- Config deprecation warnings
+- --dry-run flag for start/stop
+- cs-proxy check (diagnostics) command
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# =============================================================================
+# Circuit breaker
+# =============================================================================
+
+
+def test_health_check_resets_failures_on_success(tmp_path):
+    from csproxy.state import State
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=2,
+        last_failure=0,
+    )
+
+    tunnel = SSHTunnel(config, "test-cs", port=1080)
+    # Mock successful curl
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch("subprocess.run", return_value=mock_result):
+        tunnel.health_check()
+
+    t = state.get_tunnel_by_port(1080)
+    assert t["failures"] == 0
+    assert t["last_failure"] == 0
+
+
+def test_health_check_records_failure_on_bad_check(tmp_path):
+    from csproxy.state import State
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+
+    tunnel = SSHTunnel(config, "test-cs", port=1080)
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+
+    with patch("subprocess.run", return_value=mock_result):
+        result = tunnel.health_check()
+
+    assert result is False
+    t = state.get_tunnel_by_port(1080)
+    assert t["failures"] == 1
+
+
+def test_health_check_trips_circuit_breaker(tmp_path):
+    from csproxy.state import State
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+
+    tunnel = SSHTunnel(config, "test-cs", port=1080)
+    mock_result = MagicMock()
+    mock_result.returncode = 1
+
+    with patch("subprocess.run", return_value=mock_result):
+        # Default max_failures=3, so 3 failures should trip
+        tunnel.health_check()
+        tunnel.health_check()
+        tunnel.health_check()
+
+    t = state.get_tunnel_by_port(1080)
+    assert t["status"] == "dead"
+    assert t["failures"] == 3
+
+
+# =============================================================================
+# Config deprecation warnings
+# =============================================================================
+
+
+def test_config_load_warns_on_deprecated_key(tmp_path):
+    import yaml
+    from unittest.mock import patch
+    from csproxy.utils.config import Config
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.safe_dump({"chain": "some-value", "socks_port": 1080}))
+
+    mock_logger = MagicMock()
+    with patch("csproxy.utils.config.get_logger", return_value=mock_logger):
+        Config(config_dir=tmp_path, config_file=config_file)
+
+    warning_calls = [c for c in mock_logger.warning.call_args_list if "chain" in str(c)]
+    assert len(warning_calls) >= 1
+    assert "Deprecated config key 'chain'" in str(warning_calls[0])
+
+
+# =============================================================================
+# --dry-run flag
+# =============================================================================
+
+
+def test_cmd_stop_dry_run_does_not_call_stop(tmp_path):
+    from csproxy.proxy import cmd_stop
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    from unittest.mock import patch
+
+    config = Config(config_dir=tmp_path)
+    config._dry_run = True
+    gh = GitHubManager()
+
+    with patch("csproxy.tunnel.SSHTunnel.stop") as mock_stop:
+        result = cmd_stop([], config, gh)
+
+    assert result == 0
+    mock_stop.assert_not_called()
+
+
+def test_cmd_start_dry_run_does_not_start_tunnels(tmp_path):
+    from csproxy.proxy import cmd_start
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    from unittest.mock import patch
+
+    config = Config(config_dir=tmp_path)
+    config.set("codespace_names", ["test-cs"])
+    config._dry_run = True
+    gh = GitHubManager()
+
+    with patch("csproxy.tunnel.SSHTunnel.is_running", return_value=False):
+        with patch("csproxy.tunnel.SSHTunnel.start") as mock_start:
+            with patch("csproxy.codespace.CodespaceSelector.ensure_running"):
+                result = cmd_start([], config, gh)
+
+    assert result == 0
+    mock_start.assert_not_called()
+
+
+# =============================================================================
+# check command
+# =============================================================================
+
+
+def test_check_command_exists():
+    from csproxy.proxy import COMMANDS
+    assert "check" in COMMANDS
+    assert callable(COMMANDS["check"])
+
+
+def test_check_command_runs_without_crash(tmp_path):
+    from csproxy.proxy import cmd_check
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager()
+    result = cmd_check([], config, gh)
+    # Should return non-zero because keys/dependencies are missing,
+    # but must not raise.
+    assert isinstance(result, int)
+
+
+# =============================================================================
+# Worker jitter (indirect test via code inspection)
+# =============================================================================
+
+
+def test_worker_imports_random():
+    """Ensure _worker.py imports random for jitter."""
+    import csproxy._worker as worker_mod
+    assert "random" in dir(worker_mod)
+
+
+# =============================================================================
+# CLI --dry-run parsing
+# =============================================================================
+
+
+def test_cli_parses_dry_run_flag():
+    from csproxy.cli import main_proxy
+    from unittest.mock import patch
+
+    with patch("csproxy.proxy.COMMANDS", {"help": lambda a, c, g: 0}):
+        with patch("csproxy.proxy.show_help"):
+            result = main_proxy(["--dry-run", "help"])
+    assert result == 0

--- a/tests/test_serve_wg_security.py
+++ b/tests/test_serve_wg_security.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Security regression tests for cs-serve and cs-wg.
+
+Covers:
+- Shell injection sanitization (shlex.quote)
+- Path traversal rejection
+- File size limits
+- Stale PID validation
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# =============================================================================
+# cs-serve security tests
+# =============================================================================
+
+
+def test_upload_rejects_path_traversal():
+    from csproxy.serve import _validate_remote_path
+
+    with pytest.raises(ValueError, match="Path traversal"):
+        _validate_remote_path("../../../etc/passwd")
+
+    with pytest.raises(ValueError, match="Path traversal"):
+        _validate_remote_path("foo/../bar")
+
+
+def test_upload_rejects_absolute_path():
+    from csproxy.serve import _validate_remote_path
+
+    with pytest.raises(ValueError, match="Absolute paths"):
+        _validate_remote_path("/etc/passwd")
+
+
+def test_upload_accepts_safe_relative_path():
+    from csproxy.serve import _validate_remote_path
+
+    # Should not raise
+    _validate_remote_path("payload.txt")
+    _validate_remote_path("captures/data.bin")
+
+
+def test_upload_file_rejects_oversized(tmp_path, monkeypatch):
+    from csproxy.serve import _upload_file
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager()
+
+    big_file = tmp_path / "huge.bin"
+    big_file.write_bytes(b"x" * (100 * 1024 * 1024 + 1))
+
+    with pytest.raises(ValueError, match="File too large"):
+        _upload_file(gh, "test-cs", big_file, "huge.bin")
+
+
+def test_ssh_command_uses_shlex_quote():
+    from csproxy.serve import _ssh
+    from csproxy.github import GitHubManager
+
+    with patch("subprocess.run", return_value=MagicMock(returncode=0)) as mock_run:
+        _ssh(GitHubManager(), "test-cs", "echo hello; rm -rf /")
+
+    cmd = mock_run.call_args[0][0]
+    # The command should be passed as a single arg after '--'
+    assert cmd[-1] == "echo hello; rm -rf /"
+
+
+def test_setup_server_environment_uses_shlex_quote():
+    from csproxy.serve import _setup_server_environment
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+
+    config = Config()
+    gh = GitHubManager()
+
+    with patch("csproxy.serve._ssh", return_value=MagicMock(returncode=0)) as mock_ssh:
+        _setup_server_environment(gh, "test-cs", 9999)
+
+    # Check that at least one ssh command contains the shlex-quoted port
+    commands = [call[0][2] for call in mock_ssh.call_args_list]
+    assert any("csproxy_server_9999" in c or "9999" in c for c in commands), (
+        f"Expected shlex-quoted port in one of: {commands}"
+    )
+
+
+# =============================================================================
+# cs-wg security tests
+# =============================================================================
+
+
+def test_stop_tunnel_validates_pid_before_kill(tmp_path):
+    from csproxy.wireguard import stop_tunnel
+    from csproxy.utils.config import Config
+    from csproxy.github import GitHubManager
+    import os
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager()
+
+    # Create a stale PID file with a non-existent PID
+    wg_dir = tmp_path / "wireguard"
+    wg_dir.mkdir(parents=True, exist_ok=True)
+    socat_pid = wg_dir / "socat_local.pid"
+    ssh_pid = wg_dir / "ssh_tunnel.pid"
+    socat_pid.write_text("999999")
+    ssh_pid.write_text("999998")
+
+    # Also create the current_codespace file so stop_tunnel doesn't bail early
+    cs_file = tmp_path / "current_codespace"
+    cs_file.write_text('CODESPACE_NAME="test-cs"\n')
+
+    # Mock all the subprocess calls so we don't actually run wg/ip/pkill
+    with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+        with patch("os.kill") as mock_kill:
+            with patch("os.geteuid", return_value=0):
+                with patch("os.environ.get", return_value=None):
+                    try:
+                        stop_tunnel(config, gh)
+                    except Exception:
+                        pass  # we expect some failures due to mocking
+
+    # os.kill should be called with signal 0 (validation) before SIGTERM
+    # The first call for each PID should be signal 0
+    kill_calls = [c for c in mock_kill.call_args_list if c[0][0] in (999999, 999998)]
+    if kill_calls:
+        assert any(c[0][1] == 0 for c in kill_calls), (
+            "Expected PID validation (signal 0) before SIGTERM"
+        )
+
+
+def test_wireguard_constants_are_consistent():
+    from csproxy.wg_constants import WG_INTERFACE, WG_PORT, WG_LOCAL_IP, WG_REMOTE_IP, WG_NETWORK, TCP_RELAY_PORT
+    from csproxy import wireguard
+
+    # Ensure wireguard.py exports the same values as wg_constants
+    assert wireguard.WG_INTERFACE == WG_INTERFACE
+    assert wireguard.WG_PORT == WG_PORT
+    assert wireguard.WG_LOCAL_IP == WG_LOCAL_IP
+    assert wireguard.WG_REMOTE_IP == WG_REMOTE_IP
+    assert wireguard.WG_NETWORK == WG_NETWORK
+    assert wireguard.TCP_RELAY_PORT == TCP_RELAY_PORT
+
+
+def test_bypass_routes_are_narrower_than_slash_8():
+    from csproxy.wg_routes import _BYPASS_ROUTES
+
+    for route in _BYPASS_ROUTES:
+        cidr = route.split("/")[1]
+        prefix_len = int(cidr)
+        assert prefix_len >= 16, f"Bypass route {route} is too broad (should be /16 or narrower)"


### PR DESCRIPTION
## Summary

This PR delivers Phases 2 and 3 of the cs-proxy Python rewrite:

- **Phase 2** — UX improvements: dataclass config, profiles, smart rotation, shell completion, PAC, watch mode
- **Phase 3** — Production hardening: circuit breaker, jitter, dry-run, diagnostics, stale-connection cleanup
- **Security** — Fixes shell injection, path traversal, key leakage, stale PID kills, and reintroduces issue #5 regression guard
- **Docs** — Updated README and all user-facing documentation

## Changes

### New files
- `csproxy/_worker.py` — Detached subprocess worker for SSH reconnect loop
- `csproxy/state.py` — Atomic JSON state store with O_EXCL locking
- `csproxy/completion.py` — Bash/zsh completion generator
- `csproxy/wg_constants.py` — Shared WireGuard constants (deduplicated)
- `.github/workflows/test.yml` — CI with least-privilege permissions
- `tests/test_phase2_features.py` — 36 tests
- `tests/test_phase3_hardening.py` — 10 tests  
- `tests/test_serve_wg_security.py` — 9 security regression tests

### Modified files
- `csproxy/utils/config.py` — Dataclass rewrite with validation, profiles, env overrides
- `csproxy/tunnel.py` — Cross-platform subprocess worker, circuit breaker, crash stderr
- `csproxy/tools.py` — Smart proxy rotation via `_get_proxy_port()`
- `csproxy/proxy.py` — New commands: `check`, `pac`, `completion`; `down` now deletes; `--dry-run`
- `csproxy/display.py` — `watch_status()` ANSI auto-refresh
- `csproxy/cli.py` — `--dry-run` flag parsing
- `csproxy/serve.py` — `shlex.quote()`, path validation, file size limits
- `csproxy/wireguard.py` — `shlex.quote()`, key wipe, stale PID validation
- `csproxy/wg_setup.py`, `wg_routes.py`, `wg_monitor.py` — Security + deduplication
- `csproxy/__init__.py` — Export `State`
- `README.md`, `docs/**/*.md` — Fully updated for new features

## Testing Checklist

Please verify each item before approving:

### Automated tests
- [x] `pytest -q` passes (77 tests)
- [x] CI workflow `.github/workflows/test.yml` is valid YAML

### Config & profiles
- [x] `python3 -c "from csproxy.utils.config import _ConfigData; _ConfigData(socks_port=80)"` raises `ValueError`
- [x] Profile merge works: `cs-proxy start --profile redteam` loads preset values
- [x] Env override works: `SOCKS_PORT=9999 cs-proxy status` shows port 9999
- [x] Deprecated key warning: config with `chain:` logs a warning

### State & tunnels
- [x] `python3 -c "from csproxy import State; ..."` creates/reads/writes state.json
- [x] `state.reconcile()` marks dead PIDs as `crashed`
- [x] `state.record_failure()` trips circuit breaker after 3 failures

### CLI commands
- [x] `cs-proxy completion bash` outputs valid bash script
- [x] `cs-proxy completion zsh` outputs valid zsh script
- [x] `cs-proxy pac` outputs valid PAC with SOCKS5 directive
- [x] `cs-proxy check` runs diagnostics without crashing
- [x] `cs-proxy --dry-run start` shows actions without making changes
- [x] `cs-proxy --dry-run stop` shows actions without making changes
- [x] `cs-proxy status --watch` auto-refreshes (Ctrl+C exits cleanly)

### Proxy rotation
- [x] `_get_proxy_port()` falls back to config port when no healthy tunnels
- [x] `_get_proxy_port()` uses healthy tunnel port when state has one

### Security fixes
- [x] `csproxy.serve._validate_remote_path("../../../etc/passwd")` raises `ValueError`
- [x] `csproxy.serve._upload_file()` rejects files >100 MB
- [x] `csproxy.wireguard.stop_tunnel()` validates PID before `SIGTERM`
- [x] `check_proxy()` uses `--socks5-hostname` (issue #5 regression guard)
- [x] All remote shell commands in cs-serve/cs-wg use `shlex.quote()`

### Authenticated (requires `gh auth login`)
- [x] `cs-proxy start` creates tunnel, registers in state.json
- [x] `cs-proxy status` shows tunnel health + exit IP
- [x] `cs-tools ipcheck` shows different direct vs proxied IP
- [x] `cs-proxy down` stops tunnels + prompts to delete codespaces
- [x] `cs-proxy teardown` stops tunnels but preserves codespaces
- [x] `cs-serve file payload.bin` serves file on public URL
- [x] `cs-wg up` brings up WireGuard interface (sudo required)

## Deployment Notes

- Zero new dependencies — stdlib + existing PyYAML only
- Backward compatible: old config files load fine (unknown keys preserved)
- Migration: legacy `proxy*.pid` files auto-migrated to `state.json` on first run
