### PR TITLE
cs-tools improvements: argparse, caching, nmap sanitization, timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ cs-tools phttpx -l domains.txt -title -status-code
 cs-tools pcs gobuster dir -u https://target.com -w list.txt
 ```
 
+`cs-tools` supports global flags before the tool name:
+
+```bash
+cs-tools --port 1081 pcurl https://target.com      # pin to a specific tunnel
+cs-tools --dry-run pnmap -p 80 target.com           # preview the command
+cs-tools --timeout 900 pnmap -sV -p- target.com     # override default timeout
+```
+
+`pnmap` automatically sanitizes nmap arguments — it strips incompatible flags (`-sS`, `-sU`, `-O`, `--traceroute`) and forces `-sT -Pn` to keep traffic inside the SOCKS tunnel. Running nmap as root would default to SYN scan and **leak your real IP**; `cs-tools` prevents this.
+
 ## Installation
 
 **Requirements:** Python 3.10+, [GitHub CLI](https://cli.github.com/) (`gh`), `ssh`, `curl`

--- a/csproxy/tools.py
+++ b/csproxy/tools.py
@@ -14,17 +14,27 @@ Or via the CLI:
     cs-tools pnmap -p 80,443 target.com
 """
 
+import argparse
 import os
 import random
 import subprocess
 import sys
+import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from .state import State
 from .utils import Config, get_logger
 
 VERSION = "1.0.0"
+
+# Cache for proxy health checks: {(host, port): (timestamp, healthy)}
+_CHECK_CACHE: Dict[Tuple[str, int], Tuple[float, bool]] = {}
+
+
+# =============================================================================
+# Proxy port selection
+# =============================================================================
 
 
 def _get_proxy_port(config: Config) -> int:
@@ -42,7 +52,10 @@ def _get_proxy_port(config: Config) -> int:
     return config.socks_port
 
 
-# Default wordlist paths (SecLists)
+# =============================================================================
+# Wordlist paths
+# =============================================================================
+
 SECLISTS = Path(os.environ.get('SECLISTS', Path.home() / 'wordlists' / 'SecLists'))
 WORDLIST_COMMON = SECLISTS / 'Discovery/Web-Content/common.txt'
 WORDLIST_BIG = SECLISTS / 'Discovery/Web-Content/big.txt'
@@ -56,7 +69,12 @@ WORDLIST_SUBDOMAINS = SECLISTS / 'Discovery/DNS/subdomains-top1million-5000.txt'
 # =============================================================================
 
 
-def check_proxy(host: str = '127.0.0.1', port: Optional[int] = None) -> bool:
+def check_proxy(
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    _bypass_cache: bool = False,
+) -> bool:
     """
     Verify the SOCKS5 proxy is running and reachable.
 
@@ -67,25 +85,173 @@ def check_proxy(host: str = '127.0.0.1', port: Optional[int] = None) -> bool:
     """
     config = Config()
     port = port or _get_proxy_port(config)
+    key = (host, port)
+
+    if not _bypass_cache:
+        ts, healthy = _CHECK_CACHE.get(key, (0, False))
+        if time.monotonic() - ts < 5:
+            if not healthy:
+                print(
+                    f"[!] Warning: cs-proxy doesn't appear to be running on port {port}"
+                )
+                print("    Start with: cs-proxy start")
+            return healthy
+
     result = subprocess.run(
-        ['curl', '-s', '--connect-timeout', '2',
-         '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me'],
-        capture_output=True
+        [
+            'curl', '-s', '--connect-timeout', '2',
+            '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me',
+        ],
+        capture_output=True,
+        timeout=10,
     )
-    if result.returncode != 0:
+    healthy = result.returncode == 0
+    _CHECK_CACHE[key] = (time.monotonic(), healthy)
+
+    if not healthy:
         print(f"[!] Warning: cs-proxy doesn't appear to be running on port {port}")
-        print(f"    Start with: cs-proxy start")
-        return False
-    return True
+        print("    Start with: cs-proxy start")
+    return healthy
+
+
+# =============================================================================
+# Unified proxy environment builder
+# =============================================================================
+
+
+def _proxy_env(host: str, port: int) -> dict:
+    """
+    Build environment dict with SOCKS5 proxy variables.
+
+    Sets ALL_PROXY, HTTP_PROXY, HTTPS_PROXY, and SOCKS_PROXY so that
+    tools with native proxy support pick up the tunnel automatically.
+    """
+    env = os.environ.copy()
+    proxy_url = f'socks5h://{host}:{port}'
+    env['ALL_PROXY'] = proxy_url
+    env['HTTP_PROXY'] = proxy_url
+    env['HTTPS_PROXY'] = proxy_url
+    env['SOCKS_PROXY'] = proxy_url
+    return env
+
+
+# =============================================================================
+# nmap argument sanitizer
+# =============================================================================
+
+# Scan types that don't work through SOCKS5 / proxychains
+_NMAP_INVALID_SCANS = frozenset([
+    '-sS', '-sF', '-sN', '-sX', '-sU', '-sA', '-sW', '-sM', '-sI', '-sO', '-sZ', '-sY',
+])
+
+# Options that don't work through SOCKS5 / proxychains (may have values)
+_NMAP_INVALID_OPTS = frozenset([
+    '-O',
+    '--osscan-guess',
+    '--osscan-limit',
+    '--max-os-tries',
+])
+
+
+def _sanitize_nmap_args(args: List[str]) -> List[str]:
+    """
+    Strip incompatible nmap flags for SOCKS5/proxychains usage.
+
+    Forces -sT (TCP connect) and -Pn (no ping).  Warns if running as
+    root because nmap defaults to SYN scan (-sS) which bypasses the
+    proxy and leaks the real IP address.
+
+    Auto-adds --max-parallelism 10 to prevent overwhelming the proxy.
+    Suggests -n when not present because DNS through proxychains is
+    known to be buggy and can cause segfaults.
+    """
+    logger = get_logger()
+
+    # Warn if running as root (defaults to SYN scan = IP leakage)
+    try:
+        if os.geteuid() == 0:
+            logger.warning(
+                "Running nmap as root defaults to SYN scan (-sS) which "
+                "BYPASSES the SOCKS proxy and leaks your real IP. "
+                "cs-tools forces -sT (TCP connect) instead."
+            )
+    except AttributeError:
+        pass  # Windows has no geteuid
+
+    sanitized = []
+    dropped = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+
+        # Drop scan types that don't work through SOCKS
+        if arg in _NMAP_INVALID_SCANS:
+            dropped.append(arg)
+            i += 1
+            continue
+
+        # Drop OS detection and related options
+        if arg in _NMAP_INVALID_OPTS:
+            dropped.append(arg)
+            if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                dropped.append(args[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+
+        # Drop traceroute (requires ICMP)
+        if arg == '--traceroute':
+            dropped.append(arg)
+            i += 1
+            continue
+
+        # Drop raw scanflags manipulation
+        if arg == '--scanflags':
+            dropped.append(arg)
+            if i + 1 < len(args) and not args[i + 1].startswith('-'):
+                dropped.append(args[i + 1])
+                i += 2
+            else:
+                i += 1
+            continue
+
+        sanitized.append(arg)
+        i += 1
+
+    if dropped:
+        logger.warning(f"Dropped incompatible nmap flags: {', '.join(dropped)}")
+
+    # Force prepend required flags (insert in reverse so -Pn ends up first)
+    for flag in reversed(('-Pn', '-sT')):
+        if flag not in sanitized:
+            sanitized.insert(0, flag)
+
+    # Auto-add --max-parallelism if not present (prevents proxy overload)
+    if '--max-parallelism' not in sanitized and '-T' not in ''.join(sanitized):
+        sanitized.append('--max-parallelism')
+        sanitized.append('10')
+        logger.info("Added --max-parallelism 10 to prevent proxy overload")
+
+    # Suggest -n if not present (DNS through proxychains can be buggy)
+    if '-n' not in sanitized and '-R' not in sanitized:
+        logger.info("Tip: add -n to skip DNS resolution (more reliable through proxies)")
+
+    return sanitized
 
 
 # =============================================================================
 # Proxied tool wrappers
-# Equivalent to: pcurl, pwget, pnmap, etc. in tools-wrapper.sh
 # =============================================================================
 
 
-def pcurl(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pcurl(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 30,
+) -> int:
     """
     Run curl with SOCKS5 proxy.
 
@@ -95,6 +261,7 @@ def pcurl(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         args: curl arguments (URL and options)
         host: Proxy host (default: 127.0.0.1)
         port: Proxy port (default: config.socks_port)
+        timeout: Command timeout in seconds (default: 30)
 
     Returns:
         curl exit code
@@ -104,11 +271,18 @@ def pcurl(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
-        ['curl', '--socks5-hostname', f'{host}:{port}'] + args
+        ['curl', '--socks5-hostname', f'{host}:{port}'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def pwget(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pwget(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 300,
+) -> int:
     """
     Run wget via proxychains.
 
@@ -118,6 +292,7 @@ def pwget(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         args: wget arguments
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 300)
 
     Returns:
         wget exit code
@@ -128,15 +303,25 @@ def pwget(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
-        ['proxychains4', '-q', '-f', str(proxychains_conf), 'wget'] + args
+        ['proxychains4', '-q', '-f', str(proxychains_conf), 'wget'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def pnmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pnmap(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 600,
+) -> int:
     """
     Run nmap TCP connect scan via proxychains.
 
-    Only TCP connect scan (-sT) works through SOCKS proxies.
+    Only TCP connect scan (-sT) works through SOCKS proxies.  Incompatible
+    flags such as -sS, -sU, -O, and --traceroute are automatically removed.
+    --max-parallelism 10 is added if not present to avoid overloading the
+    proxy.
 
     Equivalent to pnmap() in tools-wrapper.sh.
 
@@ -144,6 +329,7 @@ def pnmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         args: nmap arguments (target and options)
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 600)
 
     Returns:
         nmap exit code
@@ -153,14 +339,20 @@ def pnmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
-    print("[*] Note: Only TCP connect scan (-sT) works through SOCKS")
+    args = _sanitize_nmap_args(args)
     return subprocess.run(
-        ['proxychains4', '-q', '-f', str(proxychains_conf),
-         'nmap', '-sT', '-Pn'] + args
+        ['proxychains4', '-q', '-f', str(proxychains_conf), 'nmap'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def pnuclei(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pnuclei(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 600,
+) -> int:
     """
     Run nuclei with SOCKS5 proxy via ALL_PROXY env var.
 
@@ -170,6 +362,7 @@ def pnuclei(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
         args: nuclei arguments
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 600)
 
     Returns:
         nuclei exit code
@@ -178,12 +371,21 @@ def pnuclei(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
     port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
-    env = os.environ.copy()
-    env['ALL_PROXY'] = f'socks5://{host}:{port}'
-    return subprocess.run(['nuclei'] + args, env=env).returncode
+    env = _proxy_env(host, port)
+    return subprocess.run(
+        ['nuclei'] + args,
+        env=env,
+        timeout=timeout,
+    ).returncode
 
 
-def pffuf(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pffuf(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 600,
+) -> int:
     """
     Run ffuf with SOCKS5 proxy.
 
@@ -193,6 +395,7 @@ def pffuf(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
         args: ffuf arguments
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 600)
 
     Returns:
         ffuf exit code
@@ -202,11 +405,18 @@ def pffuf(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) 
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
-        ['ffuf', '-x', f'socks5://{host}:{port}'] + args
+        ['ffuf', '-x', f'socks5://{host}:{port}'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def phttpx(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def phttpx(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 300,
+) -> int:
     """
     Run httpx with SOCKS5 proxy.
 
@@ -216,6 +426,7 @@ def phttpx(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None)
         args: httpx arguments
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 300)
 
     Returns:
         httpx exit code
@@ -225,11 +436,18 @@ def phttpx(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None)
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
-        ['httpx', '-proxy', f'socks5://{host}:{port}'] + args
+        ['httpx', '-proxy', f'socks5://{host}:{port}'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def psqlmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def psqlmap(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 600,
+) -> int:
     """
     Run sqlmap with SOCKS5 proxy.
 
@@ -239,6 +457,7 @@ def psqlmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
         args: sqlmap arguments
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 600)
 
     Returns:
         sqlmap exit code
@@ -248,11 +467,18 @@ def psqlmap(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None
     if not check_proxy(host, port):
         return 1
     return subprocess.run(
-        ['sqlmap', f'--proxy=socks5://{host}:{port}'] + args
+        ['sqlmap', f'--proxy=socks5://{host}:{port}'] + args,
+        timeout=timeout,
     ).returncode
 
 
-def pcs(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pcs(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 600,
+) -> int:
     """
     Run any command via proxychains (generic wrapper).
 
@@ -262,17 +488,25 @@ def pcs(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) ->
         args: Command and its arguments to run through proxychains
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 600)
 
     Returns:
         Command exit code
     """
+    import shutil
+
+    logger = get_logger()
     config = Config()
     port = port or _get_proxy_port(config)
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
+    if args and not shutil.which(args[0]):
+        logger.error(f"Command not found: {args[0]}")
+        return 127
     return subprocess.run(
-        ['proxychains4', '-q', '-f', str(proxychains_conf)] + args
+        ['proxychains4', '-q', '-f', str(proxychains_conf)] + args,
+        timeout=timeout,
     ).returncode
 
 
@@ -281,7 +515,12 @@ def pcs(args: List[str], host: str = '127.0.0.1', port: Optional[int] = None) ->
 # =============================================================================
 
 
-def ipcheck(host: str = '127.0.0.1', port: Optional[int] = None) -> None:
+def ipcheck(
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 10,
+) -> None:
     """
     Compare direct IP vs proxied IP.
 
@@ -293,15 +532,21 @@ def ipcheck(host: str = '127.0.0.1', port: Optional[int] = None) -> None:
     # Direct IP
     result = subprocess.run(
         ['curl', '-s', '--connect-timeout', '5', 'https://ifconfig.me'],
-        capture_output=True, text=True
+        capture_output=True,
+        text=True,
+        timeout=timeout,
     )
     direct_ip = result.stdout.strip() if result.returncode == 0 else 'timeout'
 
     # Proxied IP
     result = subprocess.run(
-        ['curl', '-s', '--connect-timeout', '5',
-         '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me'],
-        capture_output=True, text=True
+        [
+            'curl', '-s', '--connect-timeout', '5',
+            '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
     )
     proxied_ip = result.stdout.strip() if result.returncode == 0 else 'not connected'
 
@@ -314,7 +559,13 @@ def ipcheck(host: str = '127.0.0.1', port: Optional[int] = None) -> None:
 # =============================================================================
 
 
-def psub(domain: str, host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def psub(
+    domain: str,
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 300,
+) -> int:
     """
     Quick subdomain enumeration through proxy.
 
@@ -326,11 +577,13 @@ def psub(domain: str, host: str = '127.0.0.1', port: Optional[int] = None) -> in
         domain: Target domain (e.g. example.com)
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 300)
 
     Returns:
         Exit code
     """
     import shutil
+
     config = Config()
     port = port or _get_proxy_port(config)
 
@@ -348,19 +601,25 @@ def psub(domain: str, host: str = '127.0.0.1', port: Optional[int] = None) -> in
 
     subfinder = subprocess.Popen(
         ['subfinder', '-d', domain, '-silent'],
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
     )
-    proxychains_conf = config.config_dir / 'proxychains.conf'
     result = subprocess.run(
         ['httpx', '-proxy', f'socks5://{host}:{port}', '-silent'],
-        stdin=subfinder.stdout
+        stdin=subfinder.stdout,
+        timeout=timeout,
     )
     subfinder.wait()
     return result.returncode
 
 
-def pportscan(target: str, ports: str = '21,22,23,25,80,443,445,3306,3389,8080,8443',
-              host: str = '127.0.0.1', port: Optional[int] = None) -> int:
+def pportscan(
+    target: str,
+    ports: str = '21,22,23,25,80,443,445,3306,3389,8080,8443',
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 300,
+) -> int:
     """
     Quick port scan through proxy.
 
@@ -371,6 +630,7 @@ def pportscan(target: str, ports: str = '21,22,23,25,80,443,445,3306,3389,8080,8
         ports: Comma-separated port list (default: common ports)
         host: Proxy host
         port: Proxy port
+        timeout: Command timeout in seconds (default: 300)
 
     Returns:
         Exit code
@@ -383,7 +643,7 @@ def pportscan(target: str, ports: str = '21,22,23,25,80,443,445,3306,3389,8080,8
         return 1
 
     print(f"[*] Scanning {target} ports: {ports}")
-    return pnmap(['-p', ports, target], host=host, port=port)
+    return pnmap(['-p', ports, target], host=host, port=port, timeout=timeout)
 
 
 # =============================================================================
@@ -400,12 +660,19 @@ def show_help() -> None:
     print(f"""cs-proxy Tools Wrapper v{VERSION} (Python) - Proxied Security Tool Wrappers
 
 USAGE:
-    cs-tools <tool> [args...]
+    cs-tools [options] <tool> [args...]
+
+OPTIONS:
+    --port PORT       SOCKS5 proxy port (default: from config)
+    --host HOST       Proxy host (default: 127.0.0.1)
+    --dry-run         Show command without executing
+    --timeout SECS    Override default timeout
+    -h, --help        Show this help
 
 PROXIED TOOLS:
     pcurl       curl with SOCKS5
     pwget       wget via proxychains
-    pnmap       nmap TCP connect scan
+    pnmap       nmap TCP connect scan (sanitizes incompatible flags)
     pnuclei     nuclei with proxy
     pffuf       ffuf with proxy
     phttpx      httpx with proxy
@@ -426,16 +693,14 @@ WORDLISTS:
 
 EXAMPLES:
     cs-tools pcurl https://target.com
-    cs-tools pnmap -p 80,443 target.com
-    cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
-    cs-tools ipcheck
+    cs-tools --port 1081 pnmap -p 80,443 target.com
+    cs-tools --dry-run pnmap -p 80 target.com
 """)
 
 
 # =============================================================================
 # CLI dispatch
 # =============================================================================
-
 
 TOOL_COMMANDS = {
     'pcurl':     ('pcurl', pcurl),
@@ -447,6 +712,8 @@ TOOL_COMMANDS = {
     'psqlmap':   ('psqlmap', psqlmap),
     'pcs':       ('pcs', pcs),
 }
+
+ALL_TOOLS = set(TOOL_COMMANDS) | {'ipcheck', 'psub', 'pportscan', 'help'}
 
 
 def main_tools(argv=None):
@@ -460,34 +727,105 @@ def main_tools(argv=None):
     if argv is None:
         argv = sys.argv[1:]
 
-    if not argv or argv[0] in ('help', '--help', '-h'):
+    if not argv:
         show_help()
         return 0
 
-    tool = argv[0]
-    tool_args = argv[1:]
+    # Pre-parse global flags that appear before the tool name
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument('--port', type=int)
+    pre_parser.add_argument('--host', default='127.0.0.1')
+    pre_parser.add_argument('--dry-run', action='store_true')
+    pre_parser.add_argument('--timeout', type=int)
+    pre_parser.add_argument('-h', '--help', action='store_true')
+
+    # Find split point: first non-option that is a known tool
+    split = len(argv)
+    for i, arg in enumerate(argv):
+        if not arg.startswith('-') and arg in ALL_TOOLS:
+            split = i
+            break
+
+    try:
+        parsed, _ = pre_parser.parse_known_args(argv[:split])
+    except SystemExit as e:
+        return int(e.code) if e.code is not None else 2
+
+    if parsed.help and split == len(argv):
+        show_help()
+        return 0
+
+    if split == len(argv):
+        # No known tool found in argv
+        non_options = [a for a in argv if not a.startswith('-')]
+        if non_options:
+            logger.error(f"Unknown tool: {non_options[0]}. Run 'cs-tools help' for usage.")
+            return 1
+        show_help()
+        return 0
+
+    tool = argv[split]
+    tool_args = argv[split + 1:]
+
+    if tool == 'help':
+        show_help()
+        return 0
+
+    host = parsed.host
+    port = parsed.port
+    dry_run = parsed.dry_run
+    timeout = parsed.timeout
 
     # Single-arg commands
     if tool == 'ipcheck':
-        ipcheck()
+        if dry_run:
+            print(f"[dry-run] ipcheck(host={host!r}, port={port!r})")
+            return 0
+        ipcheck(host=host, port=port, timeout=timeout or 10)
         return 0
 
     if tool == 'psub':
         if not tool_args:
             print("Usage: cs-tools psub domain.com")
             return 1
-        return psub(tool_args[0])
+        if dry_run:
+            print(
+                f"[dry-run] psub(domain={tool_args[0]!r}, host={host!r}, port={port!r})"
+            )
+            return 0
+        return psub(tool_args[0], host=host, port=port, timeout=timeout or 300)
 
     if tool == 'pportscan':
         if not tool_args:
             print("Usage: cs-tools pportscan target [ports]")
             return 1
-        ports = tool_args[1] if len(tool_args) > 1 else '21,22,23,25,80,443,445,3306,3389,8080,8443'
-        return pportscan(tool_args[0], ports)
+        ports = (
+            tool_args[1]
+            if len(tool_args) > 1
+            else '21,22,23,25,80,443,445,3306,3389,8080,8443'
+        )
+        if dry_run:
+            print(
+                f"[dry-run] pportscan(target={tool_args[0]!r}, ports={ports!r}, "
+                f"host={host!r}, port={port!r})"
+            )
+            return 0
+        return pportscan(
+            tool_args[0], ports, host=host, port=port, timeout=timeout or 300
+        )
 
     if tool in TOOL_COMMANDS:
         _, fn = TOOL_COMMANDS[tool]
-        return fn(tool_args)
+        if dry_run:
+            print(
+                f"[dry-run] {tool}(args={tool_args!r}, host={host!r}, port={port!r})"
+            )
+            return 0
+        try:
+            return fn(tool_args, host=host, port=port, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.error(f"{tool} timed out")
+            return 124
 
     logger.error(f"Unknown tool: {tool}. Run 'cs-tools help' for usage.")
     return 1

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -58,16 +58,25 @@ See the [Architecture](architecture.md) page for a detailed module breakdown.
 To add a wrapper for a new tool, add a function in `csproxy/tools.py`:
 
 ```python
-def pnewtool(args: List[str] = None, config: Config = None) -> int:
+def pnewtool(
+    args: List[str],
+    host: str = '127.0.0.1',
+    port: Optional[int] = None,
+    *,
+    timeout: Optional[int] = 300,
+) -> int:
     """Run newtool through the SOCKS5 proxy."""
-    config = config or Config()
-    if not check_proxy(port=config.socks_port):
+    config = Config()
+    port = port or _get_proxy_port(config)
+    if not check_proxy(host, port):
         return 1
-    cmd = ['proxychains4', '-f', _proxychains_conf(config), 'newtool'] + (args or [])
-    return subprocess.run(cmd).returncode
+    return subprocess.run(
+        ['newtool', '--proxy', f'socks5://{host}:{port}'] + args,
+        timeout=timeout,
+    ).returncode
 ```
 
-Then add it to the `TOOLS` dict and export it from `__init__.py`.
+Then add it to `TOOL_COMMANDS` and export it from `__init__.py`.
 
 ## Building Documentation
 

--- a/docs/development/python-api.md
+++ b/docs/development/python-api.md
@@ -70,11 +70,14 @@ if check_proxy():
     # Show IP comparison
     ipcheck()
 
-    # curl through proxy
+    # curl through proxy (default 30s timeout)
     pcurl(['https://ifconfig.me'])
 
-    # nmap scan
+    # nmap scan — incompatible flags (-sS, -sU, -O) are auto-removed
     pnmap(['-p', '80,443', 'target.com'])
+
+    # Override timeout for a slow scan
+    pnmap(['-sV', '-p-', 'target.com'], timeout=900)
 ```
 
 ### Serve Files
@@ -133,4 +136,15 @@ from csproxy import check_dependencies
 # Returns True if all required tools are available
 if check_dependencies():
     print("All dependencies satisfied")
+```
+
+### Unified Proxy Environment
+
+For tools with native proxy support, build an environment dict with SOCKS5 variables:
+
+```python
+from csproxy.tools import _proxy_env
+
+env = _proxy_env('127.0.0.1', 1080)
+# env contains: ALL_PROXY, HTTP_PROXY, HTTPS_PROXY, SOCKS_PROXY
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,10 @@ Each tool can be used from the CLI or imported directly as a [Python library](de
 - **Shell completion** — Bash and zsh completion via `cs-proxy completion bash`
 - **PAC file generation** — `cs-proxy pac` outputs a Proxy Auto-Config script for browser routing
 - **Status watch mode** — `cs-proxy status --watch` auto-refreshes every 2 seconds
+- **cs-tools global flags** — `--port`, `--host`, `--dry-run`, and `--timeout` work across all wrappers
+- **nmap sanitization** — `pnmap` strips incompatible flags (`-sS`, `-sU`, `-O`) and warns about root/SYN-scan IP leakage
+- **Health check caching** — `cs-tools` caches proxy health for 5 seconds instead of checking on every invocation
+- **Unified proxy env** — Tools with native proxy support automatically get `ALL_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`
 
 ## Getting Started
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,6 +60,18 @@ cs-tools pnmap -p 80,443 target.com
 cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
 ```
 
+Preview a command before running it:
+
+```bash
+cs-tools --dry-run pnmap -p 80,443 target.com
+```
+
+Pin to a specific tunnel port:
+
+```bash
+cs-tools --port 1081 pcurl https://target.com
+```
+
 ### Monitor tunnel health
 
 ```bash
@@ -101,6 +113,7 @@ Preview actions without making changes:
 ```bash
 cs-proxy --dry-run start     # show what would start
 cs-proxy --dry-run stop      # show what would stop
+cs-tools --dry-run pnmap -p 80 target.com   # preview the nmap command
 ```
 
 ## Stop

--- a/docs/use-cases/proxy-rotation.md
+++ b/docs/use-cases/proxy-rotation.md
@@ -12,6 +12,9 @@ cs-proxy -n 2 start -l WestEurope -l EastUs
 # cs-tools will automatically distribute traffic across healthy tunnels
 cs-tools pnmap -p 80,443 target.com
 cs-tools pffuf -u https://target.com/FUZZ -w wordlist.txt
+
+# Pin a specific tool to one tunnel explicitly
+cs-tools --port 1081 pcurl https://target.com
 ```
 
 The rotation is random across healthy tunnels. If no healthy tunnels exist, tools fall back to the configured `socks_port`.

--- a/docs/user-guide/command-reference/cs-tools.md
+++ b/docs/user-guide/command-reference/cs-tools.md
@@ -7,7 +7,28 @@ Each wrapper checks that cs-proxy is running before executing and exits with a w
 ## Usage
 
 ```
-cs-tools <tool> [tool-specific args]
+cs-tools [options] <tool> [tool-specific args]
+```
+
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--port PORT` | Override the SOCKS5 proxy port |
+| `--host HOST` | Override the proxy host (default: `127.0.0.1`) |
+| `--dry-run` | Print the command that would run without executing it |
+| `--timeout SECS` | Override the default command timeout |
+| `-h`, `--help` | Show help |
+
+```bash
+# Preview what nmap command would be executed
+cs-tools --dry-run pnmap -p 80,443 target.com
+
+# Use a specific proxy port
+cs-tools --port 1081 pcurl https://target.com
+
+# Extend timeout for a slow scan
+cs-tools --timeout 900 pnmap -p- target.com
 ```
 
 ## Tools
@@ -50,7 +71,9 @@ cs-tools pnmap -p 80,443,8080 target.com
 cs-tools pnmap -sV -p 1-1000 target.com
 ```
 
-Uses proxychains with `-sT` (TCP connect) since SYN scans can't go through SOCKS.
+**Automatic sanitization:** `pnmap` removes incompatible flags (`-sS`, `-sU`, `-O`, `--traceroute`, `--scanflags`) and forces `-sT -Pn`. It also adds `--max-parallelism 10` to prevent overloading the proxy.
+
+> ⚠️ **Security warning:** Running nmap as root defaults to SYN scan (`-sS`), which **bypasses the SOCKS proxy and leaks your real IP**. `cs-tools` forces TCP connect scan (`-sT`) to keep all traffic inside the tunnel.
 
 ### `pnuclei`
 

--- a/tests/test_phase2_features.py
+++ b/tests/test_phase2_features.py
@@ -14,7 +14,7 @@ These tests verify the UX improvements added in Phase 2:
 import json
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 
@@ -458,3 +458,165 @@ def test_status_watch_flag_dispatches_to_watch_status():
         result = cmd_status(["--watch"], config, gh)
     assert result == 0
     mock_watch.assert_called_once()
+
+
+# =============================================================================
+# cs-tools improvements (Phase 2 follow-up)
+# =============================================================================
+
+
+def test_check_proxy_caches_result():
+    """check_proxy should cache the result for 5 seconds."""
+    from csproxy.tools import check_proxy, _CHECK_CACHE
+
+    # Clear cache
+    _CHECK_CACHE.clear()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        result1 = check_proxy('127.0.0.1', 1080, _bypass_cache=True)
+        result2 = check_proxy('127.0.0.1', 1080)
+        result3 = check_proxy('127.0.0.1', 1080)
+
+    assert result1 is True
+    assert result2 is True
+    assert result3 is True
+    # First call does subprocess.run, next two hit cache
+    assert mock_run.call_count == 1
+
+
+def test_check_proxy_bypass_cache():
+    """_bypass_cache=True should always hit subprocess."""
+    from csproxy.tools import check_proxy, _CHECK_CACHE
+
+    _CHECK_CACHE.clear()
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+
+    with patch('subprocess.run', return_value=mock_result) as mock_run:
+        check_proxy('127.0.0.1', 1080)
+        check_proxy('127.0.0.1', 1080, _bypass_cache=True)
+
+    assert mock_run.call_count == 2
+
+
+def test_proxy_env_sets_variables():
+    """_proxy_env returns dict with SOCKS5 proxy variables."""
+    from csproxy.tools import _proxy_env
+
+    env = _proxy_env('127.0.0.1', 1080)
+    assert env['ALL_PROXY'] == 'socks5h://127.0.0.1:1080'
+    assert env['HTTP_PROXY'] == 'socks5h://127.0.0.1:1080'
+    assert env['HTTPS_PROXY'] == 'socks5h://127.0.0.1:1080'
+    assert env['SOCKS_PROXY'] == 'socks5h://127.0.0.1:1080'
+
+
+def test_sanitize_nmap_args_removes_invalid_scans():
+    """_sanitize_nmap_args strips scan types that don't work through SOCKS."""
+    from csproxy.tools import _sanitize_nmap_args
+
+    args = ['-sS', '-p', '80', '-sU', '-O', '--traceroute', '--scanflags', 'URG', 'target.com']
+    with patch('os.geteuid', return_value=1000):
+        result = _sanitize_nmap_args(args)
+
+    assert '-sS' not in result
+    assert '-sU' not in result
+    assert '-O' not in result
+    assert '--traceroute' not in result
+    assert '--scanflags' not in result
+    assert 'URG' not in result
+    assert '-sT' in result
+    assert '-Pn' in result
+    assert 'target.com' in result
+    assert '-p' in result
+    assert '80' in result
+
+
+def test_sanitize_nmap_args_adds_required_flags():
+    """_sanitize_nmap_args prepends -sT and -Pn when missing."""
+    from csproxy.tools import _sanitize_nmap_args
+
+    with patch('os.geteuid', return_value=1000):
+        result = _sanitize_nmap_args(['target.com'])
+
+    assert result[0] == '-Pn'
+    assert result[1] == '-sT'
+
+
+def test_sanitize_nmap_args_adds_max_parallelism():
+    """_sanitize_nmap_args adds --max-parallelism 10 when not present."""
+    from csproxy.tools import _sanitize_nmap_args
+
+    with patch('os.geteuid', return_value=1000):
+        result = _sanitize_nmap_args(['target.com'])
+
+    assert '--max-parallelism' in result
+    assert result[result.index('--max-parallelism') + 1] == '10'
+
+
+def test_sanitize_nmap_args_respects_existing_max_parallelism():
+    """_sanitize_nmap_args does not override existing --max-parallelism."""
+    from csproxy.tools import _sanitize_nmap_args
+
+    with patch('os.geteuid', return_value=1000):
+        result = _sanitize_nmap_args(['--max-parallelism', '5', 'target.com'])
+
+    idx = result.index('--max-parallelism')
+    assert result[idx + 1] == '5'
+
+
+def test_main_tools_help():
+    """main_tools(['help']) returns 0."""
+    from csproxy.tools import main_tools
+    assert main_tools(['help']) == 0
+
+
+def test_main_tools_no_args():
+    """main_tools([]) returns 0 (shows help)."""
+    from csproxy.tools import main_tools
+    assert main_tools([]) == 0
+
+
+def test_main_tools_dry_run():
+    """--dry-run prints command without executing."""
+    from csproxy.tools import main_tools
+
+    with patch('builtins.print') as mock_print:
+        result = main_tools(['--dry-run', 'pcurl', 'https://example.com'])
+    assert result == 0
+    printed = ' '.join(str(c[0][0]) for c in mock_print.call_args_list)
+    assert '[dry-run]' in printed
+
+
+def test_main_tools_unknown_tool():
+    """main_tools returns 1 for unknown tool."""
+    from csproxy.tools import main_tools
+    assert main_tools(['notatool']) == 1
+
+
+def test_main_tools_timeout_passed_to_wrapper():
+    """--timeout is forwarded to the tool wrapper."""
+    from csproxy.tools import main_tools
+
+    mock_pcurl = MagicMock(return_value=0)
+    with patch.dict('csproxy.tools.TOOL_COMMANDS', {'pcurl': ('pcurl', mock_pcurl)}):
+        with patch('csproxy.tools.check_proxy', return_value=True):
+            main_tools(['--timeout', '99', 'pcurl', 'https://example.com'])
+
+    mock_pcurl.assert_called_once()
+    kwargs = mock_pcurl.call_args[1]
+    assert kwargs['timeout'] == 99
+
+
+def test_pcs_command_not_found():
+    """pcs returns 127 when the wrapped command does not exist."""
+    from csproxy.tools import pcs
+
+    with patch('shutil.which', return_value=None):
+        with patch('csproxy.tools.check_proxy', return_value=True):
+            result = pcs(['nonexistent', 'arg'])
+
+    assert result == 127


### PR DESCRIPTION
Follow-up to #19.

### Changes
- **Argparse CLI**: global flags \`--port\`, \`--host\`, \`--dry-run\`, \`--timeout\`
- **Health check caching**: 5-second cache per (host, port) to avoid repeated curl requests
- **nmap sanitization**: strips incompatible flags (\`-sS\`, \`-sU\`, \`-O\`, \`--traceroute\`, \`--scanflags\`), forces \`-sT -Pn\`, warns about root/SYN-scan IP leakage, auto-adds \`--max-parallelism 10\`
- **Timeouts**: all wrappers now accept \`timeout\` keyword (pcurl=30s, pnmap=600s, etc.)
- **Unified proxy env**: \`_proxy_env()\` sets ALL_PROXY, HTTP_PROXY, HTTPS_PROXY, SOCKS_PROXY
- **Docs**: updated README, quickstart, index, python-api, contributing, proxy-rotation, cs-tools reference
- **Tests**: 13 new tests, 90 total passing