### PR TITLE
Phase 1: foundation fixes and hermetic CLI tests

### DIFF
--- a/csproxy/__init__.py
+++ b/csproxy/__init__.py
@@ -8,7 +8,7 @@ and WireGuard VPN tunnels for security research and testing.
 
 __version__ = "1.0.0"
 __author__ = "cs-proxy contributors"
-__license__ = "MIT"
+__license__ = "Apache-2.0"
 
 from .github import GitHubManager
 from .codespace import CodespaceSelector

--- a/csproxy/cli.py
+++ b/csproxy/cli.py
@@ -218,6 +218,7 @@ def main_wg(argv=None):
         prog='cs-wg',
         description='GitHub Codespaces WireGuard VPN - full transparent tunneling',
     )
+    parser.add_argument('-c', '--codespace', help='Codespace name to use')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output')
 
     subparsers = parser.add_subparsers(dest='command', help='WireGuard command')
@@ -233,7 +234,7 @@ def main_wg(argv=None):
     sp_monitor = subparsers.add_parser('monitor', help='Traffic monitoring')
     sp_monitor.add_argument(
         'mode', nargs='?',
-        choices=['http', 'dns', 'hosts', 'conns', 'leak'],
+        choices=['http', 'dns', 'hosts', 'conns', 'all', 'leak'],
         default=None,
     )
 
@@ -249,6 +250,8 @@ def main_wg(argv=None):
     try:
         from .wireguard import COMMANDS as WG_COMMANDS
         config = Config()
+        if args.codespace:
+            config.set('codespace_name', args.codespace)
         gh = GitHubManager(config_dir=config.config_dir)
         handler = WG_COMMANDS.get(args.command)
         if handler:

--- a/csproxy/github.py
+++ b/csproxy/github.py
@@ -26,7 +26,13 @@ class GitHubManager:
             config_dir: Configuration directory (default: ~/.config/cs-proxy)
         """
         self.logger = get_logger()
-        self.config_dir = config_dir or Path.home() / '.config' / 'cs-proxy'
+        config_dir_override = os.environ.get('CS_PROXY_CONFIG_DIR')
+        if config_dir is not None:
+            self.config_dir = Path(config_dir)
+        elif config_dir_override:
+            self.config_dir = Path(config_dir_override).expanduser()
+        else:
+            self.config_dir = Path.home() / '.config' / 'cs-proxy'
         self.token_file = self.config_dir / 'gh_token'
         self._token = None
 

--- a/csproxy/serve.py
+++ b/csproxy/serve.py
@@ -9,6 +9,7 @@ through a Codespace, producing public HTTPS URLs on app.github.dev.
 import shlex
 import subprocess
 import time
+from posixpath import normpath
 from pathlib import Path
 from typing import Optional
 
@@ -83,10 +84,20 @@ def _get_available_codespace(gh: GitHubManager, config: Config) -> str:
 
 def _validate_remote_path(remote_path: str) -> None:
     """Reject paths that traverse outside the serve directory."""
-    if not remote_path or remote_path.startswith('/'):
-        raise ValueError(f"Absolute paths are not allowed: {remote_path}")
-    if '..' in remote_path:
+    if not remote_path:
+        raise ValueError("Remote path is required")
+
+    if ".." in remote_path.split("/"):
         raise ValueError(f"Path traversal is not allowed: {remote_path}")
+
+    normalized = normpath(remote_path)
+    if normalized == ".":
+        raise ValueError(f"Invalid remote path: {remote_path}")
+
+    if normalized.startswith("/"):
+        serve_root = normpath(SERVE_DIR)
+        if normalized != serve_root and not normalized.startswith(f"{serve_root}/"):
+            raise ValueError(f"Absolute paths outside {SERVE_DIR} are not allowed: {remote_path}")
 
 
 def _ssh(gh: GitHubManager, cs_name: str, command: str,

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -110,7 +110,13 @@ class Config:
         config_file: Optional[Path] = None,
     ):
         self.logger = get_logger()
-        self.config_dir = config_dir or Path.home() / ".config" / "cs-proxy"
+        config_dir_override = os.environ.get("CS_PROXY_CONFIG_DIR")
+        if config_dir is not None:
+            self.config_dir = Path(config_dir)
+        elif config_dir_override:
+            self.config_dir = Path(config_dir_override).expanduser()
+        else:
+            self.config_dir = Path.home() / ".config" / "cs-proxy"
         if config_file:
             self.config_file = Path(config_file)
         else:

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -4,7 +4,9 @@ cs-proxy uses a YAML configuration file with environment variable overrides and 
 
 ## Config File
 
-**Location:** `~/.config/cs-proxy/config.yaml`
+**Default location:** `~/.config/cs-proxy/config.yaml`
+
+Set `CS_PROXY_CONFIG_DIR` to use a different config directory.
 
 ```yaml
 # Proxy settings

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- **Python 3.8+** (3.10+ recommended)
+- **Python 3.10+**
 - **Linux or macOS** (WSL works on Windows)
 
 ### Required External Tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fluffy-barnacle"
 version = "1.0.0"
 description = "Disposable, ephemeral network infrastructure powered by GitHub Codespaces"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 keywords = ["bugbounty", "codespaces", "ephemeral", "github", "infrastructure", "red-team", "proxy", "socks5", "security", "wireguard", "vpn"]
 authors = [
@@ -21,8 +21,6 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -67,10 +65,10 @@ include = ["csproxy*"]
 
 [tool.black]
 line-length = 100
-target-version = ['py38']
+target-version = ['py310']
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core dependencies for cs-proxy
-# Python 3.8+ required
+# Python 3.10+ required
 
 # Configuration management
 pyyaml>=6.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_dir(tmp_path, monkeypatch):
+    """Keep tests from reading or writing the user's real cs-proxy config."""
+    monkeypatch.setenv("CS_PROXY_CONFIG_DIR", str(tmp_path / "cs-proxy"))

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -101,6 +101,23 @@ def test_cli_entry_points_importable():
     assert callable(main_wg)
 
 
+def test_main_wg_accepts_codespace_flag():
+    """cs-wg documents -c/--codespace, so parsing must pass it into Config."""
+    from csproxy.cli import main_wg
+
+    seen = {}
+
+    def handler(args, config, gh):
+        seen["codespace_name"] = config.codespace_name
+        return 0
+
+    with patch("csproxy.wireguard.COMMANDS", {"status": handler}):
+        result = main_wg(["-c", "my-codespace", "status"])
+
+    assert result == 0
+    assert seen["codespace_name"] == "my-codespace"
+
+
 def test_serve_script_templates_compile():
     """Embedded server script templates produce valid Python."""
     import py_compile

--- a/tests/test_fake_gh_integration.py
+++ b/tests/test_fake_gh_integration.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Integration-style CLI tests that exercise subprocess boundaries with a fake gh.
+"""
+
+import os
+import textwrap
+
+
+def _install_fake_gh(tmp_path, monkeypatch):
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    gh = bindir / "gh"
+    gh.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import sys
+
+            args = sys.argv[1:]
+
+            if args[:2] == ["auth", "status"]:
+                sys.exit(0)
+
+            if args[:2] == ["codespace", "list"]:
+                if "--json" in args:
+                    print(json.dumps([
+                        {
+                            "name": "fake-eu",
+                            "state": "Available",
+                            "repository": "owner/repo",
+                            "createdAt": "2026-01-01T00:00:00Z",
+                        }
+                    ]))
+                else:
+                    print("fake-eu")
+                sys.exit(0)
+
+            print(f"unexpected gh args: {args}", file=sys.stderr)
+            sys.exit(2)
+            """
+        )
+    )
+    gh.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}:{os.environ.get('PATH', '')}")
+    return gh
+
+
+def test_cs_proxy_list_uses_fake_gh(tmp_path, monkeypatch, capsys):
+    from csproxy.cli import main_proxy
+
+    _install_fake_gh(tmp_path, monkeypatch)
+
+    result = main_proxy(["list"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "fake-eu" in captured.out
+    assert "owner/repo" in captured.out

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 
-def test_imports():
+def check_imports():
     """Test that all modules can be imported."""
     print("[*] Testing imports...")
 
@@ -43,7 +43,7 @@ def test_imports():
         return False
 
 
-def test_logging():
+def check_logging():
     """Test logging functionality."""
     print("\n[*] Testing logging...")
 
@@ -65,7 +65,7 @@ def test_logging():
         return False
 
 
-def test_config():
+def check_config():
     """Test configuration management."""
     print("\n[*] Testing configuration...")
 
@@ -94,7 +94,7 @@ def test_config():
         return False
 
 
-def test_github_manager():
+def check_github_manager():
     """Test GitHub manager initialization."""
     print("\n[*] Testing GitHub manager...")
 
@@ -118,7 +118,7 @@ def test_github_manager():
         return False
 
 
-def test_dependencies():
+def check_dependencies():
     """Test dependency checking."""
     print("\n[*] Testing dependency checking...")
 
@@ -151,7 +151,7 @@ def test_dependencies():
         return False
 
 
-def test_exceptions():
+def check_exceptions():
     """Test custom exceptions."""
     print("\n[*] Testing exceptions...")
 
@@ -182,7 +182,7 @@ def test_exceptions():
         return False
 
 
-def test_proxy_module():
+def check_proxy_module():
     """Test Phase 2 proxy module imports and structure."""
     print("\n[*] Testing proxy module (Phase 2)...")
 
@@ -247,7 +247,7 @@ def test_proxy_module():
         return False
 
 
-def test_serve_module():
+def check_serve_module():
     """Test cs-serve module imports and structure."""
     print("\n[*] Testing serve module (cs-serve.sh conversion)...")
 
@@ -332,7 +332,7 @@ def test_serve_module():
         return False
 
 
-def test_wireguard_module():
+def check_wireguard_module():
     """Test cs-wg module imports and structure."""
     print("\n[*] Testing wireguard module (cs-wg.sh conversion)...")
 
@@ -399,7 +399,7 @@ def test_wireguard_module():
         return False
 
 
-def test_tools_module():
+def check_tools_module():
     """Test cs-tools module imports and structure."""
     print("\n[*] Testing tools module (tools-wrapper.sh conversion)...")
 
@@ -462,16 +462,16 @@ def main():
     print("=" * 70)
 
     tests = [
-        test_imports,
-        test_logging,
-        test_config,
-        test_github_manager,
-        test_dependencies,
-        test_exceptions,
-        test_proxy_module,
-        test_serve_module,
-        test_wireguard_module,
-        test_tools_module,
+        check_imports,
+        check_logging,
+        check_config,
+        check_github_manager,
+        check_dependencies,
+        check_exceptions,
+        check_proxy_module,
+        check_serve_module,
+        check_wireguard_module,
+        check_tools_module,
     ]
 
     results = []
@@ -500,9 +500,13 @@ def main():
     else:
         print(f"[-] SOME TESTS FAILED ({passed}/{total} passed)")
         print("\nPlease check the errors above and ensure:")
-        print("  - Python 3.8+ is installed")
+        print("  - Python 3.10+ is installed")
         print("  - Dependencies are installed: pip install -e .")
         return 1
+
+
+def test_installation_smoke():
+    assert main() == 0
 
 
 if __name__ == '__main__':

--- a/tests/test_phase2_features.py
+++ b/tests/test_phase2_features.py
@@ -107,6 +107,17 @@ def test_config_env_override_socks_port(monkeypatch, tmp_path):
     assert config.socks_port == 9999
 
 
+def test_config_dir_env_override(monkeypatch, tmp_path):
+    from csproxy.utils.config import Config
+
+    config_dir = tmp_path / "custom-config"
+    monkeypatch.setenv("CS_PROXY_CONFIG_DIR", str(config_dir))
+    config = Config()
+
+    assert config.config_dir == config_dir
+    assert config.config_file == config_dir / "config.yaml"
+
+
 def test_config_env_override_locations(monkeypatch, tmp_path):
     from csproxy.utils.config import Config
     monkeypatch.setenv("LOCATIONS", "WestEurope,EastUs")

--- a/tests/test_serve_wg_security.py
+++ b/tests/test_serve_wg_security.py
@@ -43,6 +43,7 @@ def test_upload_accepts_safe_relative_path():
     # Should not raise
     _validate_remote_path("payload.txt")
     _validate_remote_path("captures/data.bin")
+    _validate_remote_path("/tmp/serve/payload.txt")
 
 
 def test_upload_file_rejects_oversized(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Isolate config/state in tests with CS_PROXY_CONFIG_DIR support
- Fix command surface regressions and metadata issues
- Add fake-gh style hermetic CLI coverage

## Stack
This is PR 1 of 5. Merge first.

## Validation
- pytest -q --tb=short