### PR TITLE
Phase 2: shared runner and account infrastructure

### DIFF
--- a/csproxy/__init__.py
+++ b/csproxy/__init__.py
@@ -11,8 +11,10 @@ __author__ = "cs-proxy contributors"
 __license__ = "Apache-2.0"
 
 from .github import GitHubManager
+from .accounts import GitHubAccount
 from .codespace import CodespaceSelector
 from .proxy import ProxychainsConfig
+from .runner import CommandRunner
 from .state import State
 from .tunnel import HTTPProxyManager, SSHTunnel
 from .tools import (
@@ -41,6 +43,8 @@ __all__ = [
     '__version__',
     # Core managers
     'GitHubManager',
+    'GitHubAccount',
+    'CommandRunner',
     'SSHTunnel',
     'HTTPProxyManager',
     'CodespaceSelector',

--- a/csproxy/accounts.py
+++ b/csproxy/accounts.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Named GitHub account configuration.
+
+Accounts let future chain/pool features operate against multiple GitHub
+identities without passing PATs around as command-line arguments.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from .utils.errors import ConfigError
+
+
+@dataclass(frozen=True)
+class GitHubAccount:
+    """A named GitHub account backed by an environment variable token."""
+
+    name: str
+    token_env: str = "GH_TOKEN"
+    gh_host: str = "github.com"
+
+    @property
+    def token(self) -> Optional[str]:
+        """Return the configured token, if present in the environment."""
+        return os.environ.get(self.token_env)
+
+    def require_token(self) -> str:
+        """Return the token or raise a config error with a safe message."""
+        token = self.token
+        if not token:
+            raise ConfigError(
+                f"Account '{self.name}' requires ${self.token_env} to be set"
+            )
+        return token
+
+    @classmethod
+    def from_config(cls, config, name: str) -> "GitHubAccount":
+        """Load a named account from Config.accounts."""
+        accounts = config.get("accounts", {})
+        raw = accounts.get(name)
+        if not isinstance(raw, dict):
+            raise ConfigError(f"Unknown account: {name}")
+        token_env = raw.get("token_env")
+        if not token_env:
+            raise ConfigError(f"Account '{name}' is missing token_env")
+        return cls(
+            name=name,
+            token_env=token_env,
+            gh_host=raw.get("gh_host", "github.com"),
+        )
+
+
+def default_account() -> GitHubAccount:
+    """Return the default account that follows gh/GH_TOKEN conventions."""
+    return GitHubAccount(name="default", token_env="GH_TOKEN")

--- a/csproxy/github.py
+++ b/csproxy/github.py
@@ -12,13 +12,21 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+from .accounts import GitHubAccount
+from .runner import CommandRunner
 from .utils import GitHubAuthError, get_logger
 
 
 class GitHubManager:
     """Manages GitHub CLI operations and authentication."""
 
-    def __init__(self, config_dir: Optional[Path] = None):
+    def __init__(
+        self,
+        config_dir: Optional[Path] = None,
+        *,
+        account: Optional[GitHubAccount] = None,
+        runner: Optional[CommandRunner] = None,
+    ):
         """
         Initialize GitHub manager.
 
@@ -35,6 +43,8 @@ class GitHubManager:
             self.config_dir = Path.home() / '.config' / 'cs-proxy'
         self.token_file = self.config_dir / 'gh_token'
         self._token = None
+        self.account = account
+        self.runner = runner or CommandRunner()
 
     def load_token(self) -> Optional[str]:
         """
@@ -48,6 +58,15 @@ class GitHubManager:
             GitHub token if found, None otherwise
         """
         # Priority 1: Environment variables
+        if self.account:
+            token = self.account.token
+            if token:
+                self.logger.debug(
+                    f"Using token from ${self.account.token_env} for account {self.account.name}"
+                )
+                self._token = token
+                return token
+
         token = os.environ.get('GH_TOKEN') or os.environ.get('GITHUB_TOKEN')
         if token:
             self.logger.debug("Using GH_TOKEN from environment")
@@ -107,16 +126,18 @@ class GitHubManager:
         token = self.load_token()
 
         # Set token in environment for gh CLI
+        env = None
         if token:
-            os.environ['GH_TOKEN'] = token
+            env = {'GH_TOKEN': token}
 
         # Check if we have valid auth
         try:
-            result = subprocess.run(
-                ['gh', 'auth', 'status'],
+            result = self.runner.gh(
+                ['auth', 'status'],
                 capture_output=True,
                 text=True,
-                timeout=10
+                timeout=10,
+                env=env,
             )
 
             if result.returncode == 0:
@@ -167,12 +188,17 @@ class GitHubManager:
         self.logger.debug(f"Running: {' '.join(cmd)}")
 
         try:
-            result = subprocess.run(
+            env = None
+            token = self.load_token()
+            if token:
+                env = {'GH_TOKEN': token}
+            result = self.runner.run(
                 cmd,
                 capture_output=True,
                 text=True,
                 check=check,
-                timeout=30
+                timeout=30,
+                env=env,
             )
             return result
 

--- a/csproxy/runner.py
+++ b/csproxy/runner.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+Shared subprocess runner for cs-proxy.
+
+Centralizes command execution so CLI features can share timeout handling,
+environment injection, logging, and dry-run behavior.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass, field
+from typing import Mapping, Optional, Sequence
+
+from .utils.logging import get_logger
+
+
+@dataclass
+class CommandRunner:
+    """Small wrapper around subprocess.run with cs-proxy defaults."""
+
+    default_timeout: int = 30
+    dry_run: bool = False
+    base_env: Optional[Mapping[str, str]] = None
+    redacted_values: Sequence[str] = field(default_factory=tuple)
+
+    def _merged_env(self, env: Optional[Mapping[str, str]] = None) -> Optional[dict[str, str]]:
+        if self.base_env is None and env is None:
+            return None
+        merged = dict(os.environ)
+        if self.base_env:
+            merged.update(self.base_env)
+        if env:
+            merged.update(env)
+        return merged
+
+    def _display_cmd(self, cmd: Sequence[str]) -> str:
+        parts = []
+        redacted = {v for v in self.redacted_values if v}
+        for part in cmd:
+            parts.append("***" if part in redacted else str(part))
+        return " ".join(parts)
+
+    def run(
+        self,
+        cmd: Sequence[str],
+        *,
+        check: bool = False,
+        capture_output: bool = True,
+        text: bool = True,
+        timeout: Optional[int] = None,
+        env: Optional[Mapping[str, str]] = None,
+        input=None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        """Run a command with consistent defaults."""
+        logger = get_logger()
+        logger.debug(f"Running: {self._display_cmd(cmd)}")
+
+        if self.dry_run:
+            return subprocess.CompletedProcess(list(cmd), 0, stdout="", stderr="")
+
+        return subprocess.run(
+            list(cmd),
+            check=check,
+            capture_output=capture_output,
+            text=text,
+            timeout=self.default_timeout if timeout is None else timeout,
+            env=self._merged_env(env),
+            input=input,
+            **kwargs,
+        )
+
+    def gh(self, args: Sequence[str], **kwargs) -> subprocess.CompletedProcess:
+        """Run a GitHub CLI command."""
+        return self.run(["gh", *args], **kwargs)

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -37,6 +37,7 @@ class _ConfigData:
     cloudflare_account_id: str = ""
     locations: List[str] = field(default_factory=list)
     codespace_names: List[str] = field(default_factory=list)
+    accounts: dict = field(default_factory=dict)
     profile: str = ""
     profiles: dict = field(default_factory=dict)
 
@@ -100,6 +101,7 @@ class Config:
         "cloudflare_account_id": "",
         "locations": [],
         "codespace_names": [],
+        "accounts": {},
         "profile": "",
         "profiles": {},
     }

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -27,6 +27,14 @@ max_reconnect_delay: 300    # max delay with exponential backoff + jitter
 dns_proxy: false
 verbose: false
 
+# Optional named GitHub accounts for future pool/chain workflows.
+# Tokens are read from environment variables, never from CLI arguments.
+accounts:
+  default:
+    token_env: GH_TOKEN
+  eu:
+    token_env: GH_TOKEN_EU
+
 # Profiles — switch between presets without editing files
 profile: ""                 # active profile name (must match a key below)
 profiles:
@@ -97,6 +105,21 @@ All settings can be overridden via environment variables:
 | `MAX_RECONNECT_DELAY` | `max_reconnect_delay` | `300` | Max reconnect delay (s) |
 | `DNS_PROXY` | `dns_proxy` | `false` | Route DNS through proxy (`true`/`1`/`yes`) |
 | `VERBOSE` | `verbose` | `false` | Enable debug logging (`true`/`1`/`yes`) |
+
+### Named Accounts
+
+Named accounts let advanced workflows target different GitHub identities without
+putting PATs in config files or command history:
+
+```yaml
+accounts:
+  eu:
+    token_env: GH_TOKEN_EU
+  us:
+    token_env: GH_TOKEN_US
+```
+
+Set those environment variables before using account-aware commands.
 
 ### Additional Environment Variables
 

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -15,7 +15,8 @@ def test_csproxy_package_exports():
     import csproxy
     expected = [
         'SSHTunnel', 'HTTPProxyManager', 'CodespaceSelector', 'ProxychainsConfig',
-        'GitHubManager', 'Config', 'setup_logger', 'get_logger',
+        'GitHubManager', 'GitHubAccount', 'CommandRunner',
+        'Config', 'setup_logger', 'get_logger',
         'check_dependencies', 'CSProxyError',
         'check_proxy', 'ipcheck', 'pcurl', 'pwget', 'pnmap', 'pnuclei',
         'pffuf', 'phttpx', 'psqlmap', 'pcs', 'psub', 'pportscan',

--- a/tests/test_phase2_infrastructure.py
+++ b/tests/test_phase2_infrastructure.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Shared infrastructure tests for command execution and account config."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+
+def test_command_runner_dry_run_returns_success_without_subprocess():
+    from csproxy.runner import CommandRunner
+
+    runner = CommandRunner(dry_run=True)
+
+    with patch("subprocess.run") as mock_run:
+        result = runner.run(["gh", "auth", "status"])
+
+    assert isinstance(result, subprocess.CompletedProcess)
+    assert result.returncode == 0
+    mock_run.assert_not_called()
+
+
+def test_command_runner_merges_env(monkeypatch):
+    from csproxy.runner import CommandRunner
+
+    monkeypatch.setenv("EXISTING", "1")
+    runner = CommandRunner(base_env={"BASE": "2"})
+
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        runner.run(["echo", "ok"], env={"CALL": "3"})
+
+    env = mock_run.call_args.kwargs["env"]
+    assert env["EXISTING"] == "1"
+    assert env["BASE"] == "2"
+    assert env["CALL"] == "3"
+
+
+def test_github_account_loads_from_config(monkeypatch, tmp_path):
+    from csproxy.accounts import GitHubAccount
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    config.set("accounts", {"eu": {"token_env": "GH_TOKEN_EU", "gh_host": "github.com"}})
+    monkeypatch.setenv("GH_TOKEN_EU", "secret")
+
+    account = GitHubAccount.from_config(config, "eu")
+
+    assert account.name == "eu"
+    assert account.token_env == "GH_TOKEN_EU"
+    assert account.token == "secret"
+
+
+def test_github_account_rejects_missing_token_env(tmp_path):
+    from csproxy.accounts import GitHubAccount
+    from csproxy.utils.config import Config
+    from csproxy.utils.errors import ConfigError
+
+    config = Config(config_dir=tmp_path)
+    config.set("accounts", {"bad": {}})
+
+    with pytest.raises(ConfigError, match="missing token_env"):
+        GitHubAccount.from_config(config, "bad")
+
+
+def test_github_manager_uses_account_token(monkeypatch, tmp_path):
+    from csproxy.accounts import GitHubAccount
+    from csproxy.github import GitHubManager
+    from csproxy.runner import CommandRunner
+
+    monkeypatch.setenv("GH_TOKEN_EU", "secret")
+    runner = CommandRunner()
+    gh = GitHubManager(
+        config_dir=tmp_path,
+        account=GitHubAccount("eu", token_env="GH_TOKEN_EU"),
+        runner=runner,
+    )
+
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        assert gh.check_auth() is True
+
+    assert mock_run.call_args.kwargs["env"]["GH_TOKEN"] == "secret"


### PR DESCRIPTION
## Summary
- Add shared CommandRunner abstraction
- Add named GitHub account model backed by token environment variables
- Route GitHubManager command execution through account-aware env injection

## Stack
This is PR 2 of 5. Base: phase1-foundation.

## Validation
- pytest -q --tb=short