### PR TITLE
Phase 4: multi-account chain configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ cs-proxy chain stop eu-us
 
 The first hop runs a SOCKS relay and the second hop runs an HTTPS CONNECT exit relay. Chain mode is intended for authorized testing of region-specific routing behavior and adds latency.
 
+Named accounts can be used when each hop should be managed with a different PAT:
+
+```bash
+export GH_TOKEN_EU=...
+export GH_TOKEN_US=...
+cs-proxy account add eu --token-env GH_TOKEN_EU
+cs-proxy account add us --token-env GH_TOKEN_US
+cs-proxy chain create eu-us --hop eu:WestEurope --hop us:EastUs
+```
+
+Raw PATs are intentionally not accepted as command arguments.
+
 ### Public File Hosting
 
 ```bash

--- a/csproxy/chains.py
+++ b/csproxy/chains.py
@@ -18,6 +18,7 @@ import time
 from string import Template
 from typing import Optional
 
+from .accounts import GitHubAccount
 from .codespace import CodespaceSelector
 from .github import GitHubManager
 from .state import State
@@ -184,6 +185,33 @@ def _chain(config: Config, name: str) -> dict:
     return chain
 
 
+def parse_hop_spec(spec: str) -> dict:
+    """Parse REGION or ACCOUNT:REGION into a hop dict."""
+    if ":" in spec:
+        account, location = spec.split(":", 1)
+        if not account or not location:
+            raise ValueError(f"Invalid hop spec: {spec}")
+        return {"account": account, "location": location, "codespace_name": ""}
+    return {"location": spec, "codespace_name": ""}
+
+
+def _manager_for_hop(hop: dict, config: Config, default_gh: GitHubManager) -> GitHubManager:
+    account_name = hop.get("account", "")
+    if not account_name:
+        return default_gh
+    account = GitHubAccount.from_config(config, account_name)
+    return GitHubManager(config_dir=config.config_dir, account=account)
+
+
+def _popen_env_for_gh(gh: GitHubManager) -> Optional[dict]:
+    token = gh.load_token()
+    if not token:
+        return None
+    env = os.environ.copy()
+    env["GH_TOKEN"] = token
+    return env
+
+
 def _ssh(gh: GitHubManager, codespace: str, command: str, *, timeout: int = 30) -> subprocess.CompletedProcess:
     return gh.runner.run(
         ["gh", "codespace", "ssh", "--codespace", codespace, "--", command],
@@ -223,9 +251,11 @@ def _start_remote_script(gh: GitHubManager, codespace: str, script_path: str, la
 
 
 def _ensure_chain_hops(chain: dict, config: Config, gh: GitHubManager) -> list[dict]:
-    selector = CodespaceSelector(gh, config)
     hops = list(chain.get("hops", []))
     for idx, hop in enumerate(hops):
+        hop_gh = _manager_for_hop(hop, config, gh)
+        hop_gh.check_auth()
+        selector = CodespaceSelector(hop_gh, config)
         if hop.get("codespace_name"):
             selector.ensure_running(hop["codespace_name"])
             continue
@@ -244,7 +274,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
 
     p_create = sub.add_parser("create", help="Create a two-hop chain definition")
     p_create.add_argument("name")
-    p_create.add_argument("--hop", action="append", required=True, metavar="REGION")
+    p_create.add_argument("--hop", action="append", required=True, metavar="REGION|ACCOUNT:REGION")
 
     p_start = sub.add_parser("start", help="Start a chain")
     p_start.add_argument("name")
@@ -265,10 +295,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
         chains = _chains(config)
         chains[parsed.name] = {
             "name": parsed.name,
-            "hops": [
-                {"location": parsed.hop[0], "codespace_name": ""},
-                {"location": parsed.hop[1], "codespace_name": ""},
-            ],
+            "hops": [parse_hop_spec(parsed.hop[0]), parse_hop_spec(parsed.hop[1])],
             "hop1_port": DEFAULT_HOP1_PORT,
             "hop2_port": DEFAULT_HOP2_PORT,
         }
@@ -298,7 +325,6 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             print(f"[dry-run] Would start chain {parsed.name}")
             return 0
 
-        gh.check_auth()
         hops = _ensure_chain_hops(chain, config, gh)
         if len(hops) != 2:
             raise ValueError("Chains must have exactly two hops")
@@ -309,6 +335,8 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
         config.save()
 
         hop1, hop2 = hops
+        hop1_gh = _manager_for_hop(hop1, config, gh)
+        hop2_gh = _manager_for_hop(hop2, config, gh)
         hop1_name = hop1["codespace_name"]
         hop2_name = hop2["codespace_name"]
         hop1_port = int(chain.get("hop1_port", DEFAULT_HOP1_PORT))
@@ -324,15 +352,15 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
         exit_path = f"/tmp/csproxy_chain_exit_{hop2_port}.py"
         socks_path = f"/tmp/csproxy_chain_socks_{hop1_port}.py"
 
-        _upload(gh, hop2_name, exit_path, exit_script)
-        _start_remote_script(gh, hop2_name, exit_path, f"csproxy_chain_exit_{hop2_port}")
-        gh.run_gh_command(
+        _upload(hop2_gh, hop2_name, exit_path, exit_script)
+        _start_remote_script(hop2_gh, hop2_name, exit_path, f"csproxy_chain_exit_{hop2_port}")
+        hop2_gh.run_gh_command(
             ["codespace", "ports", "visibility", f"{hop2_port}:public", "--codespace", hop2_name],
             check=False,
         )
 
-        _upload(gh, hop1_name, socks_path, socks_script)
-        _start_remote_script(gh, hop1_name, socks_path, f"csproxy_chain_socks_{hop1_port}")
+        _upload(hop1_gh, hop1_name, socks_path, socks_script)
+        _start_remote_script(hop1_gh, hop1_name, socks_path, f"csproxy_chain_socks_{hop1_port}")
 
         fwd = subprocess.Popen(
             [
@@ -347,6 +375,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,
+            env=_popen_env_for_gh(hop1_gh),
         )
 
         State(config.config_dir).add_tunnel(
@@ -379,7 +408,8 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
         for hop in entry.get("hops", []):
             name = hop.get("codespace_name")
             if name:
-                _ssh(gh, name, "pkill -f csproxy_chain_ 2>/dev/null || true", timeout=10)
+                hop_gh = _manager_for_hop(hop, config, gh)
+                _ssh(hop_gh, name, "pkill -f csproxy_chain_ 2>/dev/null || true", timeout=10)
         state.remove_tunnel(tunnel_id=f"chain-{parsed.name}")
         logger.info(f"Stopped chain: {parsed.name}")
         return 0
@@ -392,6 +422,7 @@ def chain_help() -> str:
         """\
         Chain commands:
           cs-proxy chain create NAME --hop WestEurope --hop EastUs
+          cs-proxy chain create NAME --hop eu:WestEurope --hop us:EastUs
           cs-proxy chain start NAME [--port 1080]
           cs-proxy chain status [NAME]
           cs-proxy chain stop NAME

--- a/csproxy/display.py
+++ b/csproxy/display.py
@@ -244,6 +244,7 @@ COMMANDS:
     burp            Show Burp Suite configuration
 
     keygen          Generate SSH key for Codespace access
+    account         Manage named GitHub accounts for chain workflows
     config          Edit configuration
     logs [n]        Show last n lines of log (default: 50)
     token [token]   Set GitHub Personal Access Token

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -769,6 +769,61 @@ def cmd_completion(args, config: Config, gh: GitHubManager) -> int:
     return 0
 
 
+def cmd_account(args, config: Config, gh: GitHubManager) -> int:
+    """Manage named GitHub accounts for account-aware workflows."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="cs-proxy account")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_add = sub.add_parser("add", help="Add or update an account")
+    p_add.add_argument("name")
+    p_add.add_argument("--token-env", required=True, help="Environment variable that holds the PAT")
+    p_add.add_argument("--gh-host", default="github.com")
+
+    p_list = sub.add_parser("list", help="List configured accounts")
+    p_list.set_defaults(_list=True)
+
+    p_rm = sub.add_parser("remove", aliases=["rm"], help="Remove an account")
+    p_rm.add_argument("name")
+
+    parsed = parser.parse_args(args)
+    accounts = config.get("accounts", {})
+    if not isinstance(accounts, dict):
+        accounts = {}
+
+    if parsed.action == "add":
+        if parsed.token_env.startswith("ghp_") or parsed.token_env.startswith("github_pat_"):
+            raise ValueError("Do not pass raw tokens. Use --token-env NAME instead.")
+        accounts[parsed.name] = {
+            "token_env": parsed.token_env,
+            "gh_host": parsed.gh_host,
+        }
+        config.set("accounts", accounts)
+        config.save()
+        get_logger().info(f"Saved account '{parsed.name}' using ${parsed.token_env}")
+        return 0
+
+    if parsed.action == "list":
+        if not accounts:
+            print("No named accounts configured.")
+            return 0
+        for name, account in accounts.items():
+            token_env = account.get("token_env", "")
+            gh_host = account.get("gh_host", "github.com")
+            print(f"{name:<20} token_env={token_env:<20} host={gh_host}")
+        return 0
+
+    if parsed.action in ("remove", "rm"):
+        accounts.pop(parsed.name, None)
+        config.set("accounts", accounts)
+        config.save()
+        get_logger().info(f"Removed account '{parsed.name}'")
+        return 0
+
+    return 1
+
+
 def cmd_check(args, config: Config, gh: GitHubManager) -> int:
     """Run diagnostics and report configuration/dependency health."""
     logger = get_logger()
@@ -906,6 +961,7 @@ COMMANDS = {
     'aliases':      cmd_aliases,
     'pac':          cmd_pac,
     'completion':   cmd_completion,
+    'account':      cmd_account,
     'check':        cmd_check,
     'chain':        cmd_chain,
     'help':         cmd_help,

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -99,6 +99,7 @@ Create a two-hop Codespaces chain definition.
 
 ```bash
 cs-proxy chain create eu-us --hop WestEurope --hop EastUs
+cs-proxy chain create eu-us --hop eu:WestEurope --hop us:EastUs
 ```
 
 #### `chain start`
@@ -129,6 +130,35 @@ cs-proxy chain stop eu-us
 ```
 
 Chain mode is experimental and intentionally capped at two hops.
+
+### Named Accounts
+
+#### `account add`
+
+Store a named GitHub account that reads its PAT from an environment variable.
+
+```bash
+export GH_TOKEN_EU=...
+cs-proxy account add eu --token-env GH_TOKEN_EU
+```
+
+Raw PATs are rejected as command arguments. Use environment variables so tokens do not land in shell history.
+
+#### `account list`
+
+List configured account labels and token environment variable names.
+
+```bash
+cs-proxy account list
+```
+
+#### `account remove`
+
+Remove an account label.
+
+```bash
+cs-proxy account remove eu
+```
 
 ### HTTP Proxy
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -108,8 +108,9 @@ All settings can be overridden via environment variables:
 
 ### Named Accounts
 
-Named accounts let advanced workflows target different GitHub identities without
-putting PATs in config files or command history:
+Named accounts let advanced workflows, including multi-account chains, target
+different GitHub identities without putting PATs in config files or command
+history:
 
 ```yaml
 accounts:

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -39,7 +39,7 @@ def test_proxy_module_exports():
         'start', 'stop', 'restart', 'status', 'list', 'create',
         'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
         'config', 'logs', 'split', 'ssh', 'run', 'name',
-        'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
+        'teardown', 'down', 'delete', 'rm', 'token', 'aliases', 'account',
         'pac', 'completion', 'check', 'chain', 'help',
     }
     assert expected_commands <= set(COMMANDS.keys())

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -206,7 +206,7 @@ def check_proxy_module():
             'start', 'stop', 'restart', 'status', 'list', 'create',
             'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
             'config', 'logs', 'split', 'ssh', 'run', 'name',
-            'teardown', 'down', 'delete', 'rm', 'token', 'aliases',
+            'teardown', 'down', 'delete', 'rm', 'token', 'aliases', 'account',
             'pac', 'completion', 'check', 'chain', 'help',
         }
         registered = set(COMMANDS.keys())

--- a/tests/test_phase4_multi_account_chains.py
+++ b/tests/test_phase4_multi_account_chains.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tests for named accounts and multi-account chain definitions."""
+
+import pytest
+
+
+def test_account_add_persists_token_env(tmp_path):
+    from csproxy.proxy import cmd_account
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+
+    result = cmd_account(["add", "eu", "--token-env", "GH_TOKEN_EU"], config, gh)
+
+    assert result == 0
+    assert config.get("accounts")["eu"]["token_env"] == "GH_TOKEN_EU"
+
+
+def test_account_add_rejects_raw_pat(tmp_path):
+    from csproxy.proxy import cmd_account
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+
+    with pytest.raises(ValueError, match="raw tokens"):
+        cmd_account(["add", "bad", "--token-env", "ghp_secret"], config, gh)
+
+
+def test_chain_create_accepts_account_hop_specs(tmp_path):
+    from csproxy.chains import cmd_chain
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+
+    result = cmd_chain(
+        ["create", "eu-us", "--hop", "eu:WestEurope", "--hop", "us:EastUs"],
+        config,
+        gh,
+    )
+
+    assert result == 0
+    hops = config.get("chains")["eu-us"]["hops"]
+    assert hops[0]["account"] == "eu"
+    assert hops[0]["location"] == "WestEurope"
+    assert hops[1]["account"] == "us"
+    assert hops[1]["location"] == "EastUs"


### PR DESCRIPTION
## Summary
- Add cs-proxy account add/list/remove
- Allow chain hops to use ACCOUNT:REGION syntax
- Keep PATs out of command arguments by requiring token environment variable names

## Stack
This is PR 4 of 5. Base: phase3-single-account-chain.

## Validation
- pytest -q --tb=short