### PR TITLE
Phase 5: operator commands and live chain hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cs-proxy chain status eu-us
 cs-proxy chain stop eu-us
 ```
 
-The first hop runs a SOCKS relay and the second hop runs an HTTPS CONNECT exit relay. Chain mode is intended for authorized testing of region-specific routing behavior and adds latency.
+The first hop runs a SOCKS relay and the second hop runs a WebSocket exit relay. Chain mode is intended for authorized testing of region-specific routing behavior and adds latency.
 
 Named accounts can be used when each hop should be managed with a different PAT:
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ cs-proxy start                                # picks up unstarted tracked codes
 cs-proxy -n 2 start -l WestEurope -l EastUs  # two proxies, different regions (ports 1080 + 1081)
 cs-proxy status             # codespace state + per-tunnel exit IP
 cs-proxy status --watch     # auto-refresh every 2 seconds
+cs-proxy doctor --fix       # diagnose and repair safe local state/config issues
+cs-proxy pool list          # list managed tunnel pool entries
+cs-proxy pool rotate        # print a healthy tunnel port for scripts
 cs-proxy ssh                # interactive shell (menu if multiple codespaces tracked)
 cs-proxy env                # export statements for tools that read env vars
 cs-proxy burp               # upstream proxy config for Burp Suite

--- a/csproxy/chains.py
+++ b/csproxy/chains.py
@@ -12,6 +12,7 @@ import argparse
 import os
 import shlex
 import signal
+import socket
 import subprocess
 import textwrap
 import time
@@ -397,6 +398,19 @@ def _start_remote_script(gh: GitHubManager, codespace: str, script_path: str, la
     time.sleep(1)
 
 
+def _wait_local_forward(port: int, process: subprocess.Popen, label: str, timeout: int = 20) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"{label} port forward exited before becoming ready")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.25)
+    raise RuntimeError(f"Timed out waiting for {label} on 127.0.0.1:{port}")
+
+
 def _ensure_chain_hops(chain: dict, config: Config, gh: GitHubManager) -> list[dict]:
     hops = list(chain.get("hops", []))
     for idx, hop in enumerate(hops):
@@ -516,7 +530,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             start_new_session=True,
             env=_popen_env_for_gh(hop2_gh),
         )
-        time.sleep(2)
+        _wait_local_forward(hop2_port, exit_fwd, "exit relay")
         hop2_gh.run_gh_command(
             ["codespace", "ports", "visibility", f"{hop2_port}:public", "--codespace", hop2_name],
             check=False,
@@ -540,6 +554,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             start_new_session=True,
             env=_popen_env_for_gh(hop1_gh),
         )
+        _wait_local_forward(local_port, fwd, "chain SOCKS")
 
         State(config.config_dir).add_tunnel(
             id=f"chain-{parsed.name}",

--- a/csproxy/chains.py
+++ b/csproxy/chains.py
@@ -3,7 +3,7 @@
 Two-hop Codespaces chain management.
 
 The chain data plane is:
-  local SOCKS -> Codespace hop 1 -> HTTPS CONNECT relay -> Codespace hop 2 -> target
+  local SOCKS -> Codespace hop 1 -> WebSocket relay -> Codespace hop 2 -> target
 """
 
 from __future__ import annotations
@@ -29,52 +29,120 @@ DEFAULT_HOP2_PORT = 18081
 
 
 EXIT_RELAY_SCRIPT = r"""#!/usr/bin/env python3
+import base64
+import hashlib
 import select
 import socket
 import socketserver
+import struct
 from http.server import BaseHTTPRequestHandler
 
 PORT = $PORT
 
 
-class ConnectHandler(BaseHTTPRequestHandler):
+def _recvall(sock, n):
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise OSError("socket closed")
+        data += chunk
+    return data
+
+
+def read_frame(sock):
+    first = _recvall(sock, 2)
+    opcode = first[0] & 0x0F
+    masked = bool(first[1] & 0x80)
+    length = first[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recvall(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recvall(sock, 8))[0]
+    mask = _recvall(sock, 4) if masked else b""
+    payload = _recvall(sock, length) if length else b""
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, payload
+
+
+def send_frame(sock, payload, opcode=2):
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    if length < 126:
+        header.append(length)
+    elif length < 65536:
+        header.append(126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(127)
+        header.extend(struct.pack("!Q", length))
+    sock.sendall(header + payload)
+
+
+class WebSocketConnectHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def log_message(self, fmt, *args):
         print("[exit] " + fmt % args, flush=True)
 
-    def do_CONNECT(self):
+    def do_GET(self):
+        if self.headers.get("Upgrade", "").lower() != "websocket":
+            self.send_error(426, "WebSocket upgrade required")
+            return
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        accept = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+        self.connection.sendall(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode()
+        )
+
         try:
-            host, port_s = self.path.rsplit(":", 1)
+            opcode, target = read_frame(self.connection)
+            if opcode == 8:
+                return
+            host, port_s = target.decode().rsplit(":", 1)
             upstream = socket.create_connection((host, int(port_s)), timeout=15)
         except Exception as exc:
-            self.send_error(502, str(exc))
+            print(f"[exit] connect failed: {exc}", flush=True)
+            try:
+                send_frame(self.connection, str(exc).encode(), opcode=8)
+            except OSError:
+                pass
             return
 
-        self.send_response(200, "Connection Established")
-        self.end_headers()
         self._pump(self.connection, upstream)
 
-    def _pump(self, left, right):
-        sockets = [left, right]
-        for sock in sockets:
-            sock.setblocking(False)
+    def _pump(self, ws_sock, upstream):
+        sockets = [ws_sock, upstream]
+        upstream.setblocking(False)
         while True:
             readable, _, errored = select.select(sockets, [], sockets, 60)
             if errored or not readable:
                 break
             for sock in readable:
-                try:
-                    data = sock.recv(65536)
-                except OSError:
-                    return
-                if not data:
-                    return
-                peer = right if sock is left else left
-                try:
-                    peer.sendall(data)
-                except OSError:
-                    return
+                if sock is ws_sock:
+                    try:
+                        opcode, data = read_frame(ws_sock)
+                    except OSError:
+                        return
+                    if opcode == 8 or not data:
+                        return
+                    upstream.sendall(data)
+                else:
+                    try:
+                        data = upstream.recv(65536)
+                    except OSError:
+                        return
+                    if not data:
+                        return
+                    send_frame(ws_sock, data)
 
 
 class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -83,21 +151,92 @@ class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
 
 if __name__ == "__main__":
-    with Server(("0.0.0.0", PORT), ConnectHandler) as server:
-        print(f"exit relay listening on {PORT}", flush=True)
+    with Server(("0.0.0.0", PORT), WebSocketConnectHandler) as server:
+        print(f"websocket exit relay listening on {PORT}", flush=True)
         server.serve_forever()
 """
 
 
 SOCKS_RELAY_SCRIPT = r"""#!/usr/bin/env python3
-import http.client
+import base64
+import os
 import select
 import socket
 import socketserver
+import ssl
 import struct
 
 PORT = $PORT
 EXIT_HOST = "$EXIT_HOST"
+
+
+def _recvall(sock, n):
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise OSError("socket closed")
+        data += chunk
+    return data
+
+
+def read_frame(sock):
+    first = _recvall(sock, 2)
+    opcode = first[0] & 0x0F
+    masked = bool(first[1] & 0x80)
+    length = first[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recvall(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recvall(sock, 8))[0]
+    mask = _recvall(sock, 4) if masked else b""
+    payload = _recvall(sock, length) if length else b""
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, payload
+
+
+def send_frame(sock, payload, opcode=2, mask=True):
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    mask_bit = 0x80 if mask else 0
+    if length < 126:
+        header.append(mask_bit | length)
+    elif length < 65536:
+        header.append(mask_bit | 126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(mask_bit | 127)
+        header.extend(struct.pack("!Q", length))
+    if mask:
+        key = os.urandom(4)
+        header.extend(key)
+        payload = bytes(b ^ key[i % 4] for i, b in enumerate(payload))
+    sock.sendall(header + payload)
+
+
+def open_exit_socket(target_host, target_port):
+    raw = socket.create_connection((EXIT_HOST, 443), timeout=20)
+    ws = ssl.create_default_context().wrap_socket(raw, server_hostname=EXIT_HOST)
+    key = base64.b64encode(os.urandom(16)).decode()
+    req = (
+        "GET / HTTP/1.1\r\n"
+        f"Host: {EXIT_HOST}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    )
+    ws.sendall(req.encode())
+    response = b""
+    while b"\r\n\r\n" not in response:
+        response += ws.recv(4096)
+        if len(response) > 65536:
+            raise OSError("oversized websocket response")
+    if b" 101 " not in response.split(b"\r\n", 1)[0]:
+        raise OSError(response.split(b"\r\n", 1)[0].decode(errors="replace"))
+    send_frame(ws, f"{target_host}:{target_port}".encode())
+    return ws
 
 
 class SocksHandler(socketserver.BaseRequestHandler):
@@ -125,10 +264,7 @@ class SocksHandler(socketserver.BaseRequestHandler):
                 return
             target_port = struct.unpack("!H", client.recv(2))[0]
 
-            conn = http.client.HTTPSConnection(EXIT_HOST, timeout=20)
-            conn.set_tunnel(target_host, target_port)
-            conn.connect()
-            upstream = conn.sock
+            upstream = open_exit_socket(target_host, target_port)
 
             client.sendall(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
             self._pump(client, upstream)
@@ -139,26 +275,30 @@ class SocksHandler(socketserver.BaseRequestHandler):
             except OSError:
                 pass
 
-    def _pump(self, left, right):
-        sockets = [left, right]
-        for sock in sockets:
-            sock.setblocking(False)
+    def _pump(self, client, ws_sock):
+        sockets = [client, ws_sock]
+        client.setblocking(False)
         while True:
             readable, _, errored = select.select(sockets, [], sockets, 60)
             if errored or not readable:
                 break
             for sock in readable:
-                try:
-                    data = sock.recv(65536)
-                except OSError:
-                    return
-                if not data:
-                    return
-                peer = right if sock is left else left
-                try:
-                    peer.sendall(data)
-                except OSError:
-                    return
+                if sock is client:
+                    try:
+                        data = client.recv(65536)
+                    except OSError:
+                        return
+                    if not data:
+                        return
+                    send_frame(ws_sock, data)
+                else:
+                    try:
+                        opcode, data = read_frame(ws_sock)
+                    except OSError:
+                        return
+                    if opcode == 8 or not data:
+                        return
+                    client.sendall(data)
 
 
 class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
@@ -168,7 +308,7 @@ class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
 if __name__ == "__main__":
     with Server(("0.0.0.0", PORT), SocksHandler) as server:
-        print(f"socks relay listening on {PORT}, exit={EXIT_HOST}", flush=True)
+        print(f"socks relay listening on {PORT}, websocket exit={EXIT_HOST}", flush=True)
         server.serve_forever()
 """
 
@@ -212,12 +352,18 @@ def _popen_env_for_gh(gh: GitHubManager) -> Optional[dict]:
     return env
 
 
+def _runner_env_for_gh(gh: GitHubManager) -> Optional[dict]:
+    token = gh.load_token()
+    return {"GH_TOKEN": token} if token else None
+
+
 def _ssh(gh: GitHubManager, codespace: str, command: str, *, timeout: int = 30) -> subprocess.CompletedProcess:
     return gh.runner.run(
         ["gh", "codespace", "ssh", "--codespace", codespace, "--", command],
         capture_output=True,
         text=True,
         timeout=timeout,
+        env=_runner_env_for_gh(gh),
     )
 
 
@@ -236,6 +382,7 @@ def _upload(gh: GitHubManager, codespace: str, remote_path: str, content: str) -
         capture_output=True,
         text=True,
         timeout=30,
+        env=_runner_env_for_gh(gh),
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"Failed to upload {remote_path}")
@@ -243,7 +390,7 @@ def _upload(gh: GitHubManager, codespace: str, remote_path: str, content: str) -
 
 def _start_remote_script(gh: GitHubManager, codespace: str, script_path: str, label: str) -> None:
     quoted = shlex.quote(script_path)
-    cmd = f"pkill -f {shlex.quote(label)} 2>/dev/null || true; nohup python3 {quoted} > {quoted}.log 2>&1 &"
+    cmd = f"nohup python3 {quoted} > {quoted}.log 2>&1 &"
     result = _ssh(gh, codespace, cmd, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"Failed to start {script_path}")
@@ -354,6 +501,22 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
 
         _upload(hop2_gh, hop2_name, exit_path, exit_script)
         _start_remote_script(hop2_gh, hop2_name, exit_path, f"csproxy_chain_exit_{hop2_port}")
+        exit_fwd = subprocess.Popen(
+            [
+                "gh",
+                "codespace",
+                "ports",
+                "forward",
+                f"{hop2_port}:{hop2_port}",
+                "--codespace",
+                hop2_name,
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=_popen_env_for_gh(hop2_gh),
+        )
+        time.sleep(2)
         hop2_gh.run_gh_command(
             ["codespace", "ports", "visibility", f"{hop2_port}:public", "--codespace", hop2_name],
             check=False,
@@ -368,7 +531,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
                 "codespace",
                 "ports",
                 "forward",
-                f"{local_port}:{hop1_port}",
+                f"{hop1_port}:{local_port}",
                 "--codespace",
                 hop1_name,
             ],
@@ -385,6 +548,7 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             status="healthy",
             local_port=local_port,
             pid=fwd.pid,
+            exit_forward_pid=exit_fwd.pid,
             hops=hops,
             exit_host=exit_host,
             created=int(time.time()),
@@ -400,7 +564,9 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             logger.warning(f"Chain not running: {parsed.name}")
             return 0
         pid = entry.get("pid")
-        if pid:
+        for pid in (entry.get("pid"), entry.get("exit_forward_pid")):
+            if not pid:
+                continue
             try:
                 os.kill(int(pid), signal.SIGTERM)
             except (OSError, ValueError):

--- a/csproxy/cli.py
+++ b/csproxy/cli.py
@@ -64,7 +64,7 @@ def main_proxy(argv=None):
         crashed = state.reconcile()
         if crashed:
             logger.warning(f"Detected {len(crashed)} crashed tunnel(s): "
-                           + ", ".join(str(t['port']) for t in crashed))
+                           + ", ".join(str(t.get('port', t.get('local_port', t.get('id', '?')))) for t in crashed))
     except TimeoutError as e:
         logger.error(f"State file is locked by another process: {e}")
         return 1

--- a/csproxy/completion.py
+++ b/csproxy/completion.py
@@ -10,7 +10,7 @@ BASH_COMPLETION = """#!/bin/bash
 # cs-proxy bash completion
 _cs_proxy_completion() {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local opts="start stop restart status list create set http proxychains env burp keygen config logs split ssh run name teardown down delete rm token aliases completion pac help"
+    local opts="start stop restart status list create set http proxychains env burp keygen config logs split ssh run name teardown down delete rm token aliases account completion pac check doctor pool chain help"
     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 }
 complete -F _cs_proxy_completion cs-proxy
@@ -43,8 +43,13 @@ subcmds=(
     'rm:Alias for delete'
     'token:Set GitHub token'
     'aliases:Write shell aliases'
+    'account:Manage named GitHub accounts'
     'completion:Generate shell completion script'
     'pac:Generate Proxy Auto-Config'
+    'check:Run diagnostics'
+    'doctor:Diagnose and repair safe local issues'
+    'pool:Inspect managed tunnel pools'
+    'chain:Manage two-hop Codespaces chains'
     'help:Show help'
 )
 _describe 'command' subcmds

--- a/csproxy/display.py
+++ b/csproxy/display.py
@@ -224,6 +224,8 @@ COMMANDS:
     stop            Stop the proxy tunnel
     restart         Restart the proxy tunnel
     status          Show proxy and Codespace status
+    doctor          Diagnose setup and optionally repair local state
+    pool            Inspect and manage healthy tunnel pools
     chain           Manage two-hop Codespaces proxy chains
 
     ssh [n|name]    Open interactive shell in Codespace (menu if multiple)

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -923,6 +923,76 @@ def cmd_check(args, config: Config, gh: GitHubManager) -> int:
         return 1
 
 
+def cmd_doctor(args, config: Config, gh: GitHubManager) -> int:
+    """Run diagnostics, optionally repairing local state/config artifacts."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="cs-proxy doctor")
+    parser.add_argument("--fix", action="store_true", help="Repair safe local issues")
+    parsed = parser.parse_args(args)
+
+    logger = get_logger()
+    if parsed.fix:
+        config.ensure_dirs()
+        state = State(config.config_dir)
+        crashed = state.reconcile()
+        if crashed:
+            logger.info(f"Reconciled {len(crashed)} crashed tunnel(s)")
+        ProxychainsConfig.generate(config)
+        if not config.config_file.exists():
+            config.save()
+        logger.info("Safe local repairs complete")
+
+    return cmd_check([], config, gh)
+
+
+def cmd_pool(args, config: Config, gh: GitHubManager) -> int:
+    """Inspect and manage the local tunnel pool."""
+    import argparse
+    import random
+
+    parser = argparse.ArgumentParser(prog="cs-proxy pool")
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("list", help="List managed SSH tunnels")
+    sub.add_parser("rotate", help="Print a healthy tunnel port")
+    p_drain = sub.add_parser("drain", help="Mark a tunnel as draining")
+    p_drain.add_argument("port", type=int)
+
+    parsed = parser.parse_args(args)
+    state = State(config.config_dir)
+
+    if parsed.action == "list":
+        tunnels = state.get_tunnels(kind="ssh")
+        if not tunnels:
+            print("No SSH tunnels in the pool.")
+            return 0
+        for t in tunnels:
+            print(
+                f":{t.get('port')} {t.get('status', 'unknown'):<10} "
+                f"{t.get('codespace_name', '')}"
+            )
+        return 0
+
+    if parsed.action == "rotate":
+        healthy = state.get_tunnels(kind="ssh", status="healthy")
+        if not healthy:
+            get_logger().error("No healthy tunnels available")
+            return 1
+        print(random.choice(healthy)["port"])
+        return 0
+
+    if parsed.action == "drain":
+        tunnel = state.get_tunnel_by_port(parsed.port)
+        if not tunnel:
+            get_logger().error(f"No tunnel on port {parsed.port}")
+            return 1
+        state.update_tunnel(parsed.port, status="draining")
+        get_logger().info(f"Marked tunnel :{parsed.port} as draining")
+        return 0
+
+    return 1
+
+
 def cmd_help(args, config: Config, gh: GitHubManager) -> int:
     """Show help."""
     show_help()
@@ -963,6 +1033,8 @@ COMMANDS = {
     'completion':   cmd_completion,
     'account':      cmd_account,
     'check':        cmd_check,
+    'doctor':       cmd_doctor,
+    'pool':         cmd_pool,
     'chain':        cmd_chain,
     'help':         cmd_help,
 }

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -133,7 +133,7 @@ Start the chain and expose a local SOCKS endpoint.
 cs-proxy chain start eu-us --port 1080
 ```
 
-Traffic flows from the local SOCKS port to the first Codespace, then through an HTTPS CONNECT relay to the second Codespace, which opens the final outbound connection.
+Traffic flows from the local SOCKS port to the first Codespace, then through a WebSocket relay to the second Codespace, which opens the final outbound connection.
 
 #### `chain status`
 

--- a/docs/user-guide/command-reference/cs-proxy.md
+++ b/docs/user-guide/command-reference/cs-proxy.md
@@ -91,6 +91,29 @@ Checks:
 
 Returns exit code `0` if all checks pass, `1` if any issues are found.
 
+#### `doctor`
+
+Run diagnostics, with an optional safe local repair pass.
+
+```bash
+cs-proxy doctor
+cs-proxy doctor --fix
+```
+
+With `--fix`, doctor ensures the config directory exists, reconciles stale tunnel state, regenerates `proxychains.conf`, and creates a config file if one is missing.
+
+#### `pool`
+
+Inspect and manage locally tracked SSH tunnel pool entries.
+
+```bash
+cs-proxy pool list
+cs-proxy pool rotate       # print one healthy tunnel port
+cs-proxy pool drain 1081   # mark a tunnel as draining
+```
+
+`pool rotate` is intentionally simple so scripts can consume it directly.
+
 ### Two-Hop Chains
 
 #### `chain create`

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -40,7 +40,7 @@ def test_proxy_module_exports():
         'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
         'config', 'logs', 'split', 'ssh', 'run', 'name',
         'teardown', 'down', 'delete', 'rm', 'token', 'aliases', 'account',
-        'pac', 'completion', 'check', 'chain', 'help',
+        'pac', 'completion', 'check', 'doctor', 'pool', 'chain', 'help',
     }
     assert expected_commands <= set(COMMANDS.keys())
 

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -207,7 +207,7 @@ def check_proxy_module():
             'set', 'http', 'proxychains', 'env', 'burp', 'keygen',
             'config', 'logs', 'split', 'ssh', 'run', 'name',
             'teardown', 'down', 'delete', 'rm', 'token', 'aliases', 'account',
-            'pac', 'completion', 'check', 'chain', 'help',
+            'pac', 'completion', 'check', 'doctor', 'pool', 'chain', 'help',
         }
         registered = set(COMMANDS.keys())
         missing = expected_commands - registered

--- a/tests/test_phase3_chains.py
+++ b/tests/test_phase3_chains.py
@@ -60,3 +60,15 @@ def test_chain_start_dry_run_does_not_call_github(tmp_path):
 
     assert result == 0
     check_auth.assert_not_called()
+
+
+def test_wait_local_forward_fails_if_process_exits():
+    import pytest
+    from csproxy.chains import _wait_local_forward
+
+    class DeadProcess:
+        def poll(self):
+            return 1
+
+    with pytest.raises(RuntimeError, match="exited before becoming ready"):
+        _wait_local_forward(19080, DeadProcess(), "chain SOCKS", timeout=1)

--- a/tests/test_phase4_multi_account_chains.py
+++ b/tests/test_phase4_multi_account_chains.py
@@ -50,3 +50,18 @@ def test_chain_create_accepts_account_hop_specs(tmp_path):
     assert hops[0]["location"] == "WestEurope"
     assert hops[1]["account"] == "us"
     assert hops[1]["location"] == "EastUs"
+
+
+def test_chain_upload_injects_account_token(monkeypatch):
+    from unittest.mock import MagicMock
+    from csproxy.accounts import GitHubAccount
+    from csproxy.chains import _upload
+    from csproxy.github import GitHubManager
+
+    monkeypatch.setenv("GH_TOKEN_US", "secret")
+    gh = GitHubManager(account=GitHubAccount("us", token_env="GH_TOKEN_US"))
+    gh.runner.run = MagicMock(return_value=MagicMock(returncode=0, stderr=""))
+
+    _upload(gh, "test-cs", "/tmp/script.py", "print('ok')\n")
+
+    assert gh.runner.run.call_args.kwargs["env"] == {"GH_TOKEN": "secret"}

--- a/tests/test_phase5_operator_features.py
+++ b/tests/test_phase5_operator_features.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for operator-focused doctor and pool commands."""
+
+
+def test_pool_rotate_prints_healthy_port(tmp_path, capsys):
+    from csproxy.github import GitHubManager
+    from csproxy.proxy import cmd_pool
+    from csproxy.state import State
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    State(tmp_path).add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="cs-a",
+        port=1080,
+        pid=123,
+        status="healthy",
+    )
+
+    result = cmd_pool(["rotate"], config, GitHubManager(config_dir=tmp_path))
+
+    assert result == 0
+    assert capsys.readouterr().out.strip() == "1080"
+
+
+def test_pool_drain_marks_tunnel(tmp_path):
+    from csproxy.github import GitHubManager
+    from csproxy.proxy import cmd_pool
+    from csproxy.state import State
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    state = State(tmp_path)
+    state.add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="cs-a",
+        port=1080,
+        pid=123,
+        status="healthy",
+    )
+
+    result = cmd_pool(["drain", "1080"], config, GitHubManager(config_dir=tmp_path))
+
+    assert result == 0
+    assert state.get_tunnel_by_port(1080)["status"] == "draining"
+
+
+def test_doctor_fix_creates_config_artifacts(tmp_path):
+    from unittest.mock import patch
+    from csproxy.github import GitHubManager
+    from csproxy.proxy import cmd_doctor
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+
+    with patch("csproxy.proxy.cmd_check", return_value=0) as check:
+        result = cmd_doctor(["--fix"], config, gh)
+
+    assert result == 0
+    assert config.config_dir.exists()
+    assert (config.config_dir / "proxychains.conf").exists()
+    check.assert_called_once()


### PR DESCRIPTION
## Summary
- Add cs-proxy doctor and pool commands
- Harden chain startup around WebSocket relay behavior and local forward readiness
- Update README and command docs for account-aware two-hop chains

## Stack
This is PR 5 of 5. Base: phase4-multi-account-chains.

## Validation
- pytest -q --tb=short: 100 passed
- Live e2e: account-aware WestEurope -> EastUs chain, SOCKS curl through 127.0.0.1:19080 returned an exit IP
- Temporary Codespaces were deleted after the run