### PR TITLE
Harden csproxy relay and tunnel handling

### DIFF
--- a/csproxy/_worker.py
+++ b/csproxy/_worker.py
@@ -21,6 +21,42 @@ import sys
 import time
 from pathlib import Path
 
+from .runner import CommandRunner
+
+
+def _write_status(status_file: Path | None, status: str, **fields) -> None:
+    """Write a small status heartbeat for the parent process."""
+    if not status_file:
+        return
+    payload = {
+        "pid": os.getpid(),
+        "status": status,
+        "updated_at": time.time(),
+        **fields,
+    }
+    try:
+        status_file.write_text(json.dumps(payload, sort_keys=True))
+    except OSError:
+        return
+
+
+def _trim_log_file(log_file: Path, max_bytes: int) -> None:
+    """Keep reconnect logs bounded while preserving recent SSH diagnostics."""
+    if max_bytes <= 0 or not log_file.exists():
+        return
+    try:
+        if log_file.stat().st_size <= max_bytes:
+            return
+        keep_bytes = max(max_bytes // 2, 1)
+        with open(log_file, "rb") as fh:
+            fh.seek(-keep_bytes, os.SEEK_END)
+            recent = fh.read()
+        with open(log_file, "wb") as fh:
+            fh.write(b"[csproxy] log truncated; keeping recent output only\n")
+            fh.write(recent)
+    except OSError:
+        return
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(add_help=False)
@@ -45,7 +81,19 @@ def main() -> None:
     stop_file = Path(spec["stop_file"])
     reconnect_delay = spec.get("reconnect_delay", 5)
     max_reconnect_delay = spec.get("max_reconnect_delay", 300)
+    log_max_bytes = int(spec.get("log_max_bytes", 2_000_000))
+    ready_file = Path(spec["ready_file"]) if spec.get("ready_file") else None
+    status_file = Path(spec["status_file"]) if spec.get("status_file") else None
     gh_cmd = spec["gh_cmd"]
+
+    if ready_file:
+        try:
+            ready_file.write_text(str(os.getpid()))
+            _write_status(status_file, "ready", attempt=0)
+        except OSError as e:
+            print(f"Failed to write worker ready file: {e}", file=sys.stderr)
+            _write_status(status_file, "ready_failed", error=str(e))
+            sys.exit(1)
 
     stop_requested = False
 
@@ -70,17 +118,27 @@ def main() -> None:
         attempt += 1
         if debug:
             print(f"[worker] Attempt {attempt}: running gh ssh (delay={delay}s)", file=sys.stderr)
+        _write_status(status_file, "running", attempt=attempt, delay=delay)
 
+        _trim_log_file(log_file, log_max_bytes)
         log_mode = "a" if log_file.exists() else "w"
         try:
             with open(log_file, log_mode) as log_fd:
-                subprocess.run(gh_cmd, stdout=log_fd, stderr=log_fd, timeout=60)
+                CommandRunner().run(
+                    gh_cmd,
+                    stdout=log_fd,
+                    stderr=log_fd,
+                    capture_output=False,
+                    timeout=60,
+                )
         except subprocess.TimeoutExpired:
             if debug:
                 print("[worker] SSH command timed out, reconnecting...", file=sys.stderr)
+            _write_status(status_file, "timeout", attempt=attempt, delay=delay)
         except OSError as e:
             # Log file may have become unavailable (e.g. config dir deleted)
             print(f"[worker] Log file error: {e}", file=sys.stderr)
+            _write_status(status_file, "log_error", attempt=attempt, error=str(e))
             time.sleep(delay)
             delay = min(delay * 2, max_reconnect_delay)
             continue
@@ -102,7 +160,10 @@ def main() -> None:
         print("[worker] Exiting cleanly", file=sys.stderr)
 
     # Clean up spec file to indicate worker exited
+    _write_status(status_file, "exited", attempt=attempt)
     spec_path.unlink(missing_ok=True)
+    if ready_file:
+        ready_file.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/csproxy/chains.py
+++ b/csproxy/chains.py
@@ -10,13 +10,14 @@ from __future__ import annotations
 
 import argparse
 import os
+import secrets
 import shlex
 import signal
 import socket
 import subprocess
 import textwrap
 import time
-from string import Template
+from pathlib import Path
 from typing import Optional
 
 from .accounts import GitHubAccount
@@ -29,289 +30,15 @@ DEFAULT_HOP1_PORT = 18080
 DEFAULT_HOP2_PORT = 18081
 
 
-EXIT_RELAY_SCRIPT = r"""#!/usr/bin/env python3
-import base64
-import hashlib
-import select
-import socket
-import socketserver
-import struct
-from http.server import BaseHTTPRequestHandler
-
-PORT = $PORT
+RELAYS_DIR = Path(__file__).with_name("relays")
 
 
-def _recvall(sock, n):
-    data = b""
-    while len(data) < n:
-        chunk = sock.recv(n - len(data))
-        if not chunk:
-            raise OSError("socket closed")
-        data += chunk
-    return data
+def _relay_source(name: str) -> str:
+    return (RELAYS_DIR / name).read_text(encoding="utf-8")
 
 
-def read_frame(sock):
-    first = _recvall(sock, 2)
-    opcode = first[0] & 0x0F
-    masked = bool(first[1] & 0x80)
-    length = first[1] & 0x7F
-    if length == 126:
-        length = struct.unpack("!H", _recvall(sock, 2))[0]
-    elif length == 127:
-        length = struct.unpack("!Q", _recvall(sock, 8))[0]
-    mask = _recvall(sock, 4) if masked else b""
-    payload = _recvall(sock, length) if length else b""
-    if masked:
-        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return opcode, payload
-
-
-def send_frame(sock, payload, opcode=2):
-    header = bytearray([0x80 | opcode])
-    length = len(payload)
-    if length < 126:
-        header.append(length)
-    elif length < 65536:
-        header.append(126)
-        header.extend(struct.pack("!H", length))
-    else:
-        header.append(127)
-        header.extend(struct.pack("!Q", length))
-    sock.sendall(header + payload)
-
-
-class WebSocketConnectHandler(BaseHTTPRequestHandler):
-    protocol_version = "HTTP/1.1"
-
-    def log_message(self, fmt, *args):
-        print("[exit] " + fmt % args, flush=True)
-
-    def do_GET(self):
-        if self.headers.get("Upgrade", "").lower() != "websocket":
-            self.send_error(426, "WebSocket upgrade required")
-            return
-        key = self.headers.get("Sec-WebSocket-Key", "")
-        accept = base64.b64encode(
-            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
-        ).decode()
-        self.connection.sendall(
-            (
-                "HTTP/1.1 101 Switching Protocols\r\n"
-                "Upgrade: websocket\r\n"
-                "Connection: Upgrade\r\n"
-                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
-            ).encode()
-        )
-
-        try:
-            opcode, target = read_frame(self.connection)
-            if opcode == 8:
-                return
-            host, port_s = target.decode().rsplit(":", 1)
-            upstream = socket.create_connection((host, int(port_s)), timeout=15)
-        except Exception as exc:
-            print(f"[exit] connect failed: {exc}", flush=True)
-            try:
-                send_frame(self.connection, str(exc).encode(), opcode=8)
-            except OSError:
-                pass
-            return
-
-        self._pump(self.connection, upstream)
-
-    def _pump(self, ws_sock, upstream):
-        sockets = [ws_sock, upstream]
-        upstream.setblocking(False)
-        while True:
-            readable, _, errored = select.select(sockets, [], sockets, 60)
-            if errored or not readable:
-                break
-            for sock in readable:
-                if sock is ws_sock:
-                    try:
-                        opcode, data = read_frame(ws_sock)
-                    except OSError:
-                        return
-                    if opcode == 8 or not data:
-                        return
-                    upstream.sendall(data)
-                else:
-                    try:
-                        data = upstream.recv(65536)
-                    except OSError:
-                        return
-                    if not data:
-                        return
-                    send_frame(ws_sock, data)
-
-
-class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
-    allow_reuse_address = True
-    daemon_threads = True
-
-
-if __name__ == "__main__":
-    with Server(("0.0.0.0", PORT), WebSocketConnectHandler) as server:
-        print(f"websocket exit relay listening on {PORT}", flush=True)
-        server.serve_forever()
-"""
-
-
-SOCKS_RELAY_SCRIPT = r"""#!/usr/bin/env python3
-import base64
-import os
-import select
-import socket
-import socketserver
-import ssl
-import struct
-
-PORT = $PORT
-EXIT_HOST = "$EXIT_HOST"
-
-
-def _recvall(sock, n):
-    data = b""
-    while len(data) < n:
-        chunk = sock.recv(n - len(data))
-        if not chunk:
-            raise OSError("socket closed")
-        data += chunk
-    return data
-
-
-def read_frame(sock):
-    first = _recvall(sock, 2)
-    opcode = first[0] & 0x0F
-    masked = bool(first[1] & 0x80)
-    length = first[1] & 0x7F
-    if length == 126:
-        length = struct.unpack("!H", _recvall(sock, 2))[0]
-    elif length == 127:
-        length = struct.unpack("!Q", _recvall(sock, 8))[0]
-    mask = _recvall(sock, 4) if masked else b""
-    payload = _recvall(sock, length) if length else b""
-    if masked:
-        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
-    return opcode, payload
-
-
-def send_frame(sock, payload, opcode=2, mask=True):
-    header = bytearray([0x80 | opcode])
-    length = len(payload)
-    mask_bit = 0x80 if mask else 0
-    if length < 126:
-        header.append(mask_bit | length)
-    elif length < 65536:
-        header.append(mask_bit | 126)
-        header.extend(struct.pack("!H", length))
-    else:
-        header.append(mask_bit | 127)
-        header.extend(struct.pack("!Q", length))
-    if mask:
-        key = os.urandom(4)
-        header.extend(key)
-        payload = bytes(b ^ key[i % 4] for i, b in enumerate(payload))
-    sock.sendall(header + payload)
-
-
-def open_exit_socket(target_host, target_port):
-    raw = socket.create_connection((EXIT_HOST, 443), timeout=20)
-    ws = ssl.create_default_context().wrap_socket(raw, server_hostname=EXIT_HOST)
-    key = base64.b64encode(os.urandom(16)).decode()
-    req = (
-        "GET / HTTP/1.1\r\n"
-        f"Host: {EXIT_HOST}\r\n"
-        "Upgrade: websocket\r\n"
-        "Connection: Upgrade\r\n"
-        f"Sec-WebSocket-Key: {key}\r\n"
-        "Sec-WebSocket-Version: 13\r\n\r\n"
-    )
-    ws.sendall(req.encode())
-    response = b""
-    while b"\r\n\r\n" not in response:
-        response += ws.recv(4096)
-        if len(response) > 65536:
-            raise OSError("oversized websocket response")
-    if b" 101 " not in response.split(b"\r\n", 1)[0]:
-        raise OSError(response.split(b"\r\n", 1)[0].decode(errors="replace"))
-    send_frame(ws, f"{target_host}:{target_port}".encode())
-    return ws
-
-
-class SocksHandler(socketserver.BaseRequestHandler):
-    def handle(self):
-        client = self.request
-        try:
-            if client.recv(1) != b"\x05":
-                return
-            nmethods = client.recv(1)[0]
-            client.recv(nmethods)
-            client.sendall(b"\x05\x00")
-
-            header = client.recv(4)
-            if len(header) != 4 or header[1] != 1:
-                return
-            atyp = header[3]
-            if atyp == 1:
-                target_host = socket.inet_ntoa(client.recv(4))
-            elif atyp == 3:
-                ln = client.recv(1)[0]
-                target_host = client.recv(ln).decode()
-            elif atyp == 4:
-                target_host = socket.inet_ntop(socket.AF_INET6, client.recv(16))
-            else:
-                return
-            target_port = struct.unpack("!H", client.recv(2))[0]
-
-            upstream = open_exit_socket(target_host, target_port)
-
-            client.sendall(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
-            self._pump(client, upstream)
-        except Exception as exc:
-            print(f"[socks] {exc}", flush=True)
-            try:
-                client.sendall(b"\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00")
-            except OSError:
-                pass
-
-    def _pump(self, client, ws_sock):
-        sockets = [client, ws_sock]
-        client.setblocking(False)
-        while True:
-            readable, _, errored = select.select(sockets, [], sockets, 60)
-            if errored or not readable:
-                break
-            for sock in readable:
-                if sock is client:
-                    try:
-                        data = client.recv(65536)
-                    except OSError:
-                        return
-                    if not data:
-                        return
-                    send_frame(ws_sock, data)
-                else:
-                    try:
-                        opcode, data = read_frame(ws_sock)
-                    except OSError:
-                        return
-                    if opcode == 8 or not data:
-                        return
-                    client.sendall(data)
-
-
-class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
-    allow_reuse_address = True
-    daemon_threads = True
-
-
-if __name__ == "__main__":
-    with Server(("0.0.0.0", PORT), SocksHandler) as server:
-        print(f"socks relay listening on {PORT}, websocket exit={EXIT_HOST}", flush=True)
-        server.serve_forever()
-"""
+EXIT_RELAY_SCRIPT = _relay_source("exit_relay.py")
+SOCKS_RELAY_SCRIPT = _relay_source("socks_relay.py")
 
 
 def _chains(config: Config) -> dict:
@@ -324,6 +51,15 @@ def _chain(config: Config, name: str) -> dict:
     if not isinstance(chain, dict):
         raise ValueError(f"Unknown chain: {name}")
     return chain
+
+
+def _chain_secret(chain: dict) -> str:
+    """Return the per-chain relay secret, creating one for older configs."""
+    secret = str(chain.get("relay_secret") or "")
+    if not secret:
+        secret = secrets.token_urlsafe(32)
+        chain["relay_secret"] = secret
+    return secret
 
 
 def parse_hop_spec(spec: str) -> dict:
@@ -389,9 +125,19 @@ def _upload(gh: GitHubManager, codespace: str, remote_path: str, content: str) -
         raise RuntimeError(result.stderr.strip() or f"Failed to upload {remote_path}")
 
 
-def _start_remote_script(gh: GitHubManager, codespace: str, script_path: str, label: str) -> None:
+def _start_remote_script(
+    gh: GitHubManager,
+    codespace: str,
+    script_path: str,
+    label: str,
+    *,
+    env: Optional[dict[str, str]] = None,
+) -> None:
     quoted = shlex.quote(script_path)
-    cmd = f"nohup python3 {quoted} > {quoted}.log 2>&1 &"
+    env_prefix = ""
+    if env:
+        env_prefix = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items()) + " "
+    cmd = f"{env_prefix}nohup python3 {quoted} > {quoted}.log 2>&1 &"
     result = _ssh(gh, codespace, cmd, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"Failed to start {script_path}")
@@ -411,6 +157,71 @@ def _wait_local_forward(port: int, process: subprocess.Popen, label: str, timeou
     raise RuntimeError(f"Timed out waiting for {label} on 127.0.0.1:{port}")
 
 
+def _terminate_process(process: Optional[subprocess.Popen]) -> None:
+    """Best-effort termination for local gh port-forward processes."""
+    if process is None or process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=3)
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            process.kill()
+        except OSError:
+            pass
+
+
+def _cleanup_remote_script(gh: GitHubManager, codespace: str, script_path: str) -> None:
+    """Best-effort cleanup for uploaded chain scripts and logs."""
+    if not codespace or not script_path:
+        return
+    quoted = shlex.quote(script_path)
+    process_pattern = script_path
+    if process_pattern.startswith("/"):
+        process_pattern = "[/]" + process_pattern[1:]
+    process_pattern = shlex.quote(f"[p]ython3 .*{process_pattern}")
+    try:
+        _ssh(
+            gh,
+            codespace,
+            "for pid in $(pgrep -f "
+            f"{process_pattern} 2>/dev/null); do kill \"$pid\" 2>/dev/null || true; done; "
+            f"rm -f {quoted} {quoted}.log",
+            timeout=10,
+        )
+    except Exception:
+        pass
+
+
+def _upload_secret_file(gh: GitHubManager, codespace: str, remote_path: str, secret: str) -> None:
+    _upload(gh, codespace, remote_path, secret + "\n")
+    result = _ssh(gh, codespace, f"chmod 600 {shlex.quote(remote_path)}", timeout=10)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"Failed to secure {remote_path}")
+
+
+def _cleanup_remote_file(gh: GitHubManager, codespace: str, remote_path: str) -> None:
+    if not codespace or not remote_path:
+        return
+    try:
+        _ssh(gh, codespace, f"rm -f {shlex.quote(remote_path)}", timeout=10)
+    except Exception:
+        pass
+
+
+def _set_port_private(gh: GitHubManager, codespace: str, port: int) -> None:
+    """Best-effort reset for public chain relay ports."""
+    if not codespace or not port:
+        return
+    try:
+        gh.run_gh_command(
+            ["codespace", "ports", "visibility", f"{port}:private", "--codespace", codespace],
+            check=False,
+        )
+    except Exception:
+        pass
+
+
 def _ensure_chain_hops(chain: dict, config: Config, gh: GitHubManager) -> list[dict]:
     hops = list(chain.get("hops", []))
     for idx, hop in enumerate(hops):
@@ -428,93 +239,89 @@ def _ensure_chain_hops(chain: dict, config: Config, gh: GitHubManager) -> list[d
     return hops
 
 
-def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
-    """Manage two-hop Codespaces proxy chains."""
-    parser = argparse.ArgumentParser(prog="cs-proxy chain")
-    sub = parser.add_subparsers(dest="action", required=True)
-
-    p_create = sub.add_parser("create", help="Create a two-hop chain definition")
-    p_create.add_argument("name")
-    p_create.add_argument("--hop", action="append", required=True, metavar="REGION|ACCOUNT:REGION")
-
-    p_start = sub.add_parser("start", help="Start a chain")
-    p_start.add_argument("name")
-    p_start.add_argument("--port", type=int, default=None)
-
-    p_status = sub.add_parser("status", help="Show chain status")
-    p_status.add_argument("name", nargs="?")
-
-    p_stop = sub.add_parser("stop", help="Stop a chain")
-    p_stop.add_argument("name")
-
-    parsed = parser.parse_args(args)
+def _cmd_chain_create(parsed, config: Config) -> int:
     logger = get_logger()
+    if len(parsed.hop) != 2:
+        raise ValueError("Exactly two --hop values are required")
+    chains = _chains(config)
+    chains[parsed.name] = {
+        "name": parsed.name,
+        "hops": [parse_hop_spec(parsed.hop[0]), parse_hop_spec(parsed.hop[1])],
+        "hop1_port": DEFAULT_HOP1_PORT,
+        "hop2_port": DEFAULT_HOP2_PORT,
+        "relay_secret": secrets.token_urlsafe(32),
+    }
+    config.set("chains", chains)
+    config.save()
+    logger.info(f"Created chain: {parsed.name}")
+    return 0
 
-    if parsed.action == "create":
-        if len(parsed.hop) != 2:
-            raise ValueError("Exactly two --hop values are required")
-        chains = _chains(config)
-        chains[parsed.name] = {
-            "name": parsed.name,
-            "hops": [parse_hop_spec(parsed.hop[0]), parse_hop_spec(parsed.hop[1])],
-            "hop1_port": DEFAULT_HOP1_PORT,
-            "hop2_port": DEFAULT_HOP2_PORT,
-        }
-        config.set("chains", chains)
-        config.save()
-        logger.info(f"Created chain: {parsed.name}")
+
+def _cmd_chain_status(parsed, config: Config) -> int:
+    state = State(config.config_dir)
+    entries = state.get_tunnels(kind="chain")
+    if parsed.name:
+        entries = [e for e in entries if e.get("name") == parsed.name]
+    if not entries:
+        print("No running chains.")
         return 0
+    for entry in entries:
+        print(f"{entry.get('name')}: {entry.get('status')} local=:{entry.get('local_port')}")
+        for hop in entry.get("hops", []):
+            print(f"  - {hop.get('codespace_name')} {hop.get('location', '')}")
+    return 0
 
-    if parsed.action == "status":
-        state = State(config.config_dir)
-        entries = state.get_tunnels(kind="chain")
-        if parsed.name:
-            entries = [e for e in entries if e.get("name") == parsed.name]
-        if not entries:
-            print("No running chains.")
-            return 0
-        for entry in entries:
-            print(f"{entry.get('name')}: {entry.get('status')} local=:{entry.get('local_port')}")
-            for hop in entry.get("hops", []):
-                print(f"  - {hop.get('codespace_name')} {hop.get('location', '')}")
-        return 0
 
+def _persist_chain(config: Config, name: str, chain: dict) -> None:
+    chains = _chains(config)
+    chains[name] = chain
+    config.set("chains", chains)
+    config.save()
+
+
+def _cmd_chain_start(parsed, config: Config, gh: GitHubManager) -> int:
+    logger = get_logger()
     chain = _chain(config, parsed.name)
+    if getattr(config, "_dry_run", False):
+        print(f"[dry-run] Would start chain {parsed.name}")
+        return 0
 
-    if parsed.action == "start":
-        if getattr(config, "_dry_run", False):
-            print(f"[dry-run] Would start chain {parsed.name}")
-            return 0
+    hops = _ensure_chain_hops(chain, config, gh)
+    if len(hops) != 2:
+        raise ValueError("Chains must have exactly two hops")
 
-        hops = _ensure_chain_hops(chain, config, gh)
-        if len(hops) != 2:
-            raise ValueError("Chains must have exactly two hops")
+    hop1, hop2 = hops
+    hop1_gh = _manager_for_hop(hop1, config, gh)
+    hop2_gh = _manager_for_hop(hop2, config, gh)
+    hop1_name = hop1["codespace_name"]
+    hop2_name = hop2["codespace_name"]
+    hop1_port = int(chain.get("hop1_port", DEFAULT_HOP1_PORT))
+    hop2_port = int(chain.get("hop2_port", DEFAULT_HOP2_PORT))
+    local_port = parsed.port or config.socks_port
+    exit_host = f"{hop2_name}-{hop2_port}.app.github.dev"
+    relay_secret = _chain_secret(chain)
+    _persist_chain(config, parsed.name, chain)
 
-        chains = _chains(config)
-        chains[parsed.name] = chain
-        config.set("chains", chains)
-        config.save()
+    exit_path = f"/tmp/csproxy_chain_exit_{hop2_port}.py"
+    socks_path = f"/tmp/csproxy_chain_socks_{hop1_port}.py"
+    exit_secret_path = f"/tmp/csproxy_chain_exit_{hop2_port}.secret"
+    socks_secret_path = f"/tmp/csproxy_chain_socks_{hop1_port}.secret"
+    fwd: Optional[subprocess.Popen] = None
+    exit_fwd: Optional[subprocess.Popen] = None
 
-        hop1, hop2 = hops
-        hop1_gh = _manager_for_hop(hop1, config, gh)
-        hop2_gh = _manager_for_hop(hop2, config, gh)
-        hop1_name = hop1["codespace_name"]
-        hop2_name = hop2["codespace_name"]
-        hop1_port = int(chain.get("hop1_port", DEFAULT_HOP1_PORT))
-        hop2_port = int(chain.get("hop2_port", DEFAULT_HOP2_PORT))
-        local_port = parsed.port or config.socks_port
-        exit_host = f"{hop2_name}-{hop2_port}.app.github.dev"
-
-        exit_script = Template(EXIT_RELAY_SCRIPT).substitute(PORT=hop2_port)
-        socks_script = Template(SOCKS_RELAY_SCRIPT).substitute(
-            PORT=hop1_port,
-            EXIT_HOST=exit_host,
+    try:
+        _upload(hop2_gh, hop2_name, exit_path, EXIT_RELAY_SCRIPT)
+        _upload_secret_file(hop2_gh, hop2_name, exit_secret_path, relay_secret)
+        _start_remote_script(
+            hop2_gh,
+            hop2_name,
+            exit_path,
+            f"csproxy_chain_exit_{hop2_port}",
+            env={
+                "CS_PROXY_RELAY_PORT": str(hop2_port),
+                "CS_PROXY_RELAY_SECRET_FILE": exit_secret_path,
+            },
         )
-        exit_path = f"/tmp/csproxy_chain_exit_{hop2_port}.py"
-        socks_path = f"/tmp/csproxy_chain_socks_{hop1_port}.py"
-
-        _upload(hop2_gh, hop2_name, exit_path, exit_script)
-        _start_remote_script(hop2_gh, hop2_name, exit_path, f"csproxy_chain_exit_{hop2_port}")
         exit_fwd = subprocess.Popen(
             [
                 "gh",
@@ -536,8 +343,19 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             check=False,
         )
 
-        _upload(hop1_gh, hop1_name, socks_path, socks_script)
-        _start_remote_script(hop1_gh, hop1_name, socks_path, f"csproxy_chain_socks_{hop1_port}")
+        _upload(hop1_gh, hop1_name, socks_path, SOCKS_RELAY_SCRIPT)
+        _upload_secret_file(hop1_gh, hop1_name, socks_secret_path, relay_secret)
+        _start_remote_script(
+            hop1_gh,
+            hop1_name,
+            socks_path,
+            f"csproxy_chain_socks_{hop1_port}",
+            env={
+                "CS_PROXY_RELAY_PORT": str(hop1_port),
+                "CS_PROXY_RELAY_SECRET_FILE": socks_secret_path,
+                "CS_PROXY_EXIT_HOST": exit_host,
+            },
+        )
 
         fwd = subprocess.Popen(
             [
@@ -566,36 +384,89 @@ def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
             exit_forward_pid=exit_fwd.pid,
             hops=hops,
             exit_host=exit_host,
+            hop1_port=hop1_port,
+            hop2_port=hop2_port,
             created=int(time.time()),
         )
         logger.info(f"Chain {parsed.name} started: socks5://127.0.0.1:{local_port}")
         logger.info(f"Exit relay: https://{exit_host}/")
         return 0
+    except Exception:
+        _terminate_process(fwd)
+        _terminate_process(exit_fwd)
+        _cleanup_remote_script(hop1_gh, hop1_name, socks_path)
+        _cleanup_remote_script(hop2_gh, hop2_name, exit_path)
+        _cleanup_remote_file(hop1_gh, hop1_name, socks_secret_path)
+        _cleanup_remote_file(hop2_gh, hop2_name, exit_secret_path)
+        _set_port_private(hop1_gh, hop1_name, hop1_port)
+        _set_port_private(hop2_gh, hop2_name, hop2_port)
+        State(config.config_dir).remove_tunnel(tunnel_id=f"chain-{parsed.name}")
+        raise
 
-    if parsed.action == "stop":
-        state = State(config.config_dir)
-        entry = next((e for e in state.get_tunnels(kind="chain") if e.get("name") == parsed.name), None)
-        if not entry:
-            logger.warning(f"Chain not running: {parsed.name}")
-            return 0
-        pid = entry.get("pid")
-        for pid in (entry.get("pid"), entry.get("exit_forward_pid")):
-            if not pid:
-                continue
-            try:
-                os.kill(int(pid), signal.SIGTERM)
-            except (OSError, ValueError):
-                pass
-        for hop in entry.get("hops", []):
-            name = hop.get("codespace_name")
-            if name:
-                hop_gh = _manager_for_hop(hop, config, gh)
-                _ssh(hop_gh, name, "pkill -f csproxy_chain_ 2>/dev/null || true", timeout=10)
-        state.remove_tunnel(tunnel_id=f"chain-{parsed.name}")
-        logger.info(f"Stopped chain: {parsed.name}")
+
+def _cmd_chain_stop(parsed, config: Config, gh: GitHubManager) -> int:
+    logger = get_logger()
+    state = State(config.config_dir)
+    entry = next((e for e in state.get_tunnels(kind="chain") if e.get("name") == parsed.name), None)
+    if not entry:
+        logger.warning(f"Chain not running: {parsed.name}")
         return 0
+    for pid in (entry.get("pid"), entry.get("exit_forward_pid")):
+        if not pid:
+            continue
+        try:
+            os.kill(int(pid), signal.SIGTERM)
+        except (OSError, ValueError):
+            pass
+    for hop_idx, hop in enumerate(entry.get("hops", [])):
+        name = hop.get("codespace_name")
+        if name:
+            hop_gh = _manager_for_hop(hop, config, gh)
+            port = int(
+                entry.get("hop1_port" if hop_idx == 0 else "hop2_port")
+                or (DEFAULT_HOP1_PORT if hop_idx == 0 else DEFAULT_HOP2_PORT)
+            )
+            _ssh(
+                hop_gh,
+                name,
+                "for pid in $(pgrep -f '[p]ython3 .*[/]tmp/csproxy_chain_' 2>/dev/null); "
+                "do kill \"$pid\" 2>/dev/null || true; done; "
+                "rm -f /tmp/csproxy_chain_*",
+                timeout=10,
+            )
+            _set_port_private(hop_gh, name, port)
+    state.remove_tunnel(tunnel_id=f"chain-{parsed.name}")
+    logger.info(f"Stopped chain: {parsed.name}")
+    return 0
 
-    return 1
+
+def cmd_chain(args, config: Config, gh: GitHubManager) -> int:
+    """Manage two-hop Codespaces proxy chains."""
+    parser = argparse.ArgumentParser(prog="cs-proxy chain")
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    p_create = sub.add_parser("create", help="Create a two-hop chain definition")
+    p_create.add_argument("name")
+    p_create.add_argument("--hop", action="append", required=True, metavar="REGION|ACCOUNT:REGION")
+
+    p_start = sub.add_parser("start", help="Start a chain")
+    p_start.add_argument("name")
+    p_start.add_argument("--port", type=int, default=None)
+
+    p_status = sub.add_parser("status", help="Show chain status")
+    p_status.add_argument("name", nargs="?")
+
+    p_stop = sub.add_parser("stop", help="Stop a chain")
+    p_stop.add_argument("name")
+
+    parsed = parser.parse_args(args)
+    handlers = {
+        "create": lambda: _cmd_chain_create(parsed, config),
+        "status": lambda: _cmd_chain_status(parsed, config),
+        "start": lambda: _cmd_chain_start(parsed, config, gh),
+        "stop": lambda: _cmd_chain_stop(parsed, config, gh),
+    }
+    return handlers[parsed.action]()
 
 
 def chain_help() -> str:

--- a/csproxy/display.py
+++ b/csproxy/display.py
@@ -7,9 +7,9 @@ Extracted from proxy.py for modularity.
 """
 
 import os
-import subprocess
 from typing import Optional
 
+from .runner import CommandRunner
 from .utils import Config, get_logger
 
 
@@ -167,7 +167,7 @@ def _show_status_body(config: Config, gh) -> None:
     elif active:
         print(f"\nCodespace:       {active}")
 
-    result = subprocess.run(
+    result = CommandRunner().run(
         ['curl', '-s', '--connect-timeout', '5', 'https://ifconfig.me'],
         capture_output=True,
         text=True,

--- a/csproxy/github.py
+++ b/csproxy/github.py
@@ -46,6 +46,14 @@ class GitHubManager:
         self.account = account
         self.runner = runner or CommandRunner()
 
+    def _register_redaction(self, token: str) -> None:
+        """Ensure loaded tokens are never printed by CommandRunner debug logs."""
+        if not token:
+            return
+        existing = [value for value in self.runner.redacted_values if value]
+        if token not in existing:
+            self.runner.redacted_values = tuple([*existing, token])
+
     def load_token(self) -> Optional[str]:
         """
         Load GitHub token from various sources.
@@ -65,12 +73,14 @@ class GitHubManager:
                     f"Using token from ${self.account.token_env} for account {self.account.name}"
                 )
                 self._token = token
+                self._register_redaction(token)
                 return token
 
         token = os.environ.get('GH_TOKEN') or os.environ.get('GITHUB_TOKEN')
         if token:
             self.logger.debug("Using GH_TOKEN from environment")
             self._token = token
+            self._register_redaction(token)
             return token
 
         # Priority 2: Token file
@@ -80,6 +90,7 @@ class GitHubManager:
                 if token:
                     self.logger.debug(f"Using GH_TOKEN from {self.token_file}")
                     self._token = token
+                    self._register_redaction(token)
                     return token
             except (OSError, PermissionError) as e:
                 self.logger.warning(f"Could not read token file {self.token_file}: {e}")
@@ -106,6 +117,7 @@ class GitHubManager:
 
             self.logger.info(f"Saved GitHub token to {self.token_file}")
             self._token = token
+            self._register_redaction(token)
 
         except (OSError, PermissionError) as e:
             raise OSError(f"Could not save token to {self.token_file}: {e}")

--- a/csproxy/locking.py
+++ b/csproxy/locking.py
@@ -1,0 +1,61 @@
+"""Cross-platform file locking helpers for csproxy state files."""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+try:
+    import portalocker  # type: ignore
+except ImportError:  # pragma: no cover - exercised by the stdlib fallback tests
+    portalocker = None
+
+if os.name == "nt":  # pragma: no cover - Windows-only fallback
+    import msvcrt
+else:
+    import fcntl
+
+
+@contextmanager
+def file_lock(path: Path, *, timeout: float = 5.0) -> Iterator[None]:
+    """Acquire an exclusive advisory lock on ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if portalocker is not None:
+        try:
+            with portalocker.Lock(str(path), mode="a+", timeout=timeout):
+                yield
+            return
+        except portalocker.exceptions.LockException as exc:
+            raise TimeoutError(
+                f"Could not acquire state lock ({path}). "
+                "Another cs-proxy process may be running."
+            ) from exc
+
+    with open(path, "a+") as lock_file:
+        start = time.time()
+        while True:
+            try:
+                if os.name == "nt":  # pragma: no cover - Windows-only fallback
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError:
+                if time.time() - start > timeout:
+                    raise TimeoutError(
+                        f"Could not acquire state lock ({path}). "
+                        "Another cs-proxy process may be running."
+                    )
+                time.sleep(0.05)
+
+        try:
+            yield
+        finally:
+            if os.name == "nt":  # pragma: no cover - Windows-only fallback
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -9,12 +9,12 @@ integration with common security tools.
 
 import os
 import shutil
-import subprocess
 import time
 from pathlib import Path
 from typing import Optional
 
 from .github import GitHubManager
+from .runner import CommandRunner
 from .state import State
 from .chains import cmd_chain
 from .utils import (
@@ -95,9 +95,10 @@ def generate_ssh_key(config: Config) -> None:
             return
 
     logger.info("Generating SSH key for Codespace access...")
+    runner = CommandRunner()
 
     datestamp = time.strftime('%Y%m%d')
-    result = subprocess.run(
+    result = runner.run(
         [
             'ssh-keygen', '-t', 'ed25519',
             '-f', str(key_file),
@@ -139,16 +140,17 @@ def set_github_token(token: str, config: Config, gh: GitHubManager) -> None:
     if not token:
         raise ValueError("No token provided")
 
-    if not (token.startswith('ghp_') or token.startswith('ghs_')):
-        logger.warning("Token doesn't match expected format (ghp_* or ghs_*)")
+    if not (token.startswith('ghp_') or token.startswith('ghs_') or token.startswith('github_pat_')):
+        logger.warning("Token doesn't match expected format (ghp_*, ghs_*, or github_pat_*)")
         answer = input("Continue anyway? [y/N] ").strip().lower()
         if answer != 'y':
             raise ValueError("Aborted")
 
     logger.info("Validating token...")
     os.environ['GH_TOKEN'] = token
+    gh.runner.redacted_values = tuple([*gh.runner.redacted_values, token])
 
-    result = subprocess.run(['gh', 'auth', 'status'], capture_output=True)
+    result = gh.runner.run(['gh', 'auth', 'status'], capture_output=True, env={'GH_TOKEN': token})
     if result.returncode != 0:
         raise GitHubAuthError("Token validation failed. Check scopes: codespace, repo")
 
@@ -527,8 +529,10 @@ def cmd_run(args, config: Config, gh: GitHubManager) -> int:
     selector = CodespaceSelector(gh, config)
     selector.ensure_running(codespace)
 
-    result = subprocess.run(
-        ['gh', 'codespace', 'ssh', '--codespace', codespace, '--'] + args
+    result = gh.runner.run(
+        ['gh', 'codespace', 'ssh', '--codespace', codespace, '--'] + args,
+        capture_output=False,
+        timeout=None,
     )
     return result.returncode
 
@@ -841,7 +845,7 @@ def cmd_check(args, config: Config, gh: GitHubManager) -> int:
     # 1. GitHub CLI
     if shutil.which('gh'):
         _ok("gh CLI is installed")
-        result = subprocess.run(['gh', 'auth', 'status'], capture_output=True, text=True)
+        result = gh.runner.run(['gh', 'auth', 'status'], capture_output=True, text=True)
         if result.returncode == 0:
             _ok("gh CLI is authenticated")
         else:

--- a/csproxy/relays/__init__.py
+++ b/csproxy/relays/__init__.py
@@ -1,0 +1,2 @@
+"""Remote relay programs uploaded to Codespaces by chain mode."""
+

--- a/csproxy/relays/exit_relay.py
+++ b/csproxy/relays/exit_relay.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""WebSocket-to-TCP exit relay for csproxy chain mode."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import select
+import socket
+import socketserver
+import struct
+from http.server import BaseHTTPRequestHandler
+from pathlib import Path
+
+
+def _env_required(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _secret() -> str:
+    secret_file = os.environ.get("CS_PROXY_RELAY_SECRET_FILE", "")
+    if secret_file:
+        return Path(secret_file).read_text().strip()
+    return _env_required("CS_PROXY_RELAY_SECRET")
+
+
+PORT = int(_env_required("CS_PROXY_RELAY_PORT"))
+RELAY_SECRET = _secret()
+
+
+def _recvall(sock, n):
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise OSError("socket closed")
+        data += chunk
+    return data
+
+
+def read_frame(sock):
+    first = _recvall(sock, 2)
+    opcode = first[0] & 0x0F
+    masked = bool(first[1] & 0x80)
+    length = first[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recvall(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recvall(sock, 8))[0]
+    mask = _recvall(sock, 4) if masked else b""
+    payload = _recvall(sock, length) if length else b""
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, payload
+
+
+def send_frame(sock, payload, opcode=2):
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    if length < 126:
+        header.append(length)
+    elif length < 65536:
+        header.append(126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(127)
+        header.extend(struct.pack("!Q", length))
+    sock.sendall(header + payload)
+
+
+class WebSocketConnectHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        print("[exit] " + fmt % args, flush=True)
+
+    def do_GET(self):
+        if self.headers.get("Upgrade", "").lower() != "websocket":
+            self.send_error(426, "WebSocket upgrade required")
+            return
+        provided_secret = self.headers.get("X-CSProxy-Chain-Secret", "")
+        if not hmac.compare_digest(provided_secret, RELAY_SECRET):
+            self.send_response(403)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        accept = base64.b64encode(
+            hashlib.sha1((key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()).digest()
+        ).decode()
+        self.connection.sendall(
+            (
+                "HTTP/1.1 101 Switching Protocols\r\n"
+                "Upgrade: websocket\r\n"
+                "Connection: Upgrade\r\n"
+                f"Sec-WebSocket-Accept: {accept}\r\n\r\n"
+            ).encode()
+        )
+
+        try:
+            opcode, target = read_frame(self.connection)
+            if opcode == 8:
+                return
+            host, port_s = target.decode().rsplit(":", 1)
+            upstream = socket.create_connection((host, int(port_s)), timeout=15)
+        except Exception as exc:
+            print(f"[exit] connect failed: {exc}", flush=True)
+            try:
+                send_frame(self.connection, str(exc).encode(), opcode=8)
+            except OSError:
+                pass
+            return
+
+        self._pump(self.connection, upstream)
+
+    def _pump(self, ws_sock, upstream):
+        sockets = [ws_sock, upstream]
+        upstream.setblocking(False)
+        while True:
+            readable, _, errored = select.select(sockets, [], sockets, 60)
+            if errored or not readable:
+                break
+            for sock in readable:
+                if sock is ws_sock:
+                    try:
+                        opcode, data = read_frame(ws_sock)
+                    except OSError:
+                        return
+                    if opcode == 8 or not data:
+                        return
+                    upstream.sendall(data)
+                else:
+                    try:
+                        data = upstream.recv(65536)
+                    except OSError:
+                        return
+                    if not data:
+                        return
+                    send_frame(ws_sock, data)
+
+
+class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> None:
+    with Server(("0.0.0.0", PORT), WebSocketConnectHandler) as server:
+        print(f"websocket exit relay listening on {PORT}", flush=True)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/csproxy/relays/socks_relay.py
+++ b/csproxy/relays/socks_relay.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""SOCKS-to-WebSocket relay for csproxy chain mode."""
+
+from __future__ import annotations
+
+import base64
+import os
+import select
+import socket
+import socketserver
+import ssl
+import struct
+from pathlib import Path
+
+
+def _env_required(name: str) -> str:
+    value = os.environ.get(name, "")
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _secret() -> str:
+    secret_file = os.environ.get("CS_PROXY_RELAY_SECRET_FILE", "")
+    if secret_file:
+        return Path(secret_file).read_text().strip()
+    return _env_required("CS_PROXY_RELAY_SECRET")
+
+
+PORT = int(_env_required("CS_PROXY_RELAY_PORT"))
+EXIT_HOST = _env_required("CS_PROXY_EXIT_HOST")
+RELAY_SECRET = _secret()
+
+
+def _recvall(sock, n):
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise OSError("socket closed")
+        data += chunk
+    return data
+
+
+def read_frame(sock):
+    first = _recvall(sock, 2)
+    opcode = first[0] & 0x0F
+    masked = bool(first[1] & 0x80)
+    length = first[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", _recvall(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", _recvall(sock, 8))[0]
+    mask = _recvall(sock, 4) if masked else b""
+    payload = _recvall(sock, length) if length else b""
+    if masked:
+        payload = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    return opcode, payload
+
+
+def send_frame(sock, payload, opcode=2, mask=True):
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    mask_bit = 0x80 if mask else 0
+    if length < 126:
+        header.append(mask_bit | length)
+    elif length < 65536:
+        header.append(mask_bit | 126)
+        header.extend(struct.pack("!H", length))
+    else:
+        header.append(mask_bit | 127)
+        header.extend(struct.pack("!Q", length))
+    if mask:
+        key = os.urandom(4)
+        header.extend(key)
+        payload = bytes(b ^ key[i % 4] for i, b in enumerate(payload))
+    sock.sendall(header + payload)
+
+
+def open_exit_socket(target_host, target_port):
+    raw = socket.create_connection((EXIT_HOST, 443), timeout=20)
+    ws = ssl.create_default_context().wrap_socket(raw, server_hostname=EXIT_HOST)
+    key = base64.b64encode(os.urandom(16)).decode()
+    req = (
+        "GET / HTTP/1.1\r\n"
+        f"Host: {EXIT_HOST}\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\n"
+        f"X-CSProxy-Chain-Secret: {RELAY_SECRET}\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n"
+    )
+    ws.sendall(req.encode())
+    response = b""
+    while b"\r\n\r\n" not in response:
+        response += ws.recv(4096)
+        if len(response) > 65536:
+            raise OSError("oversized websocket response")
+    if b" 101 " not in response.split(b"\r\n", 1)[0]:
+        raise OSError(response.split(b"\r\n", 1)[0].decode(errors="replace"))
+    send_frame(ws, f"{target_host}:{target_port}".encode())
+    return ws
+
+
+class SocksHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        client = self.request
+        try:
+            if client.recv(1) != b"\x05":
+                return
+            nmethods = client.recv(1)[0]
+            client.recv(nmethods)
+            client.sendall(b"\x05\x00")
+
+            header = client.recv(4)
+            if len(header) != 4 or header[1] != 1:
+                return
+            atyp = header[3]
+            if atyp == 1:
+                target_host = socket.inet_ntoa(client.recv(4))
+            elif atyp == 3:
+                ln = client.recv(1)[0]
+                target_host = client.recv(ln).decode()
+            elif atyp == 4:
+                target_host = socket.inet_ntop(socket.AF_INET6, client.recv(16))
+            else:
+                return
+            target_port = struct.unpack("!H", client.recv(2))[0]
+
+            upstream = open_exit_socket(target_host, target_port)
+
+            client.sendall(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
+            self._pump(client, upstream)
+        except Exception as exc:
+            print(f"[socks] {exc}", flush=True)
+            try:
+                client.sendall(b"\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00")
+            except OSError:
+                pass
+
+    def _pump(self, client, ws_sock):
+        sockets = [client, ws_sock]
+        client.setblocking(False)
+        while True:
+            readable, _, errored = select.select(sockets, [], sockets, 60)
+            if errored or not readable:
+                break
+            for sock in readable:
+                if sock is client:
+                    try:
+                        data = client.recv(65536)
+                    except OSError:
+                        return
+                    if not data:
+                        return
+                    send_frame(ws_sock, data)
+                else:
+                    try:
+                        opcode, data = read_frame(ws_sock)
+                    except OSError:
+                        return
+                    if opcode == 8 or not data:
+                        return
+                    client.sendall(data)
+
+
+class Server(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def main() -> None:
+    with Server(("0.0.0.0", PORT), SocksHandler) as server:
+        print(f"socks relay listening on {PORT}, websocket exit={EXIT_HOST}", flush=True)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/csproxy/runner.py
+++ b/csproxy/runner.py
@@ -15,15 +15,31 @@ from typing import Mapping, Optional, Sequence
 
 from .utils.logging import get_logger
 
+_DEFAULT_TIMEOUT = object()
+
 
 @dataclass
 class CommandRunner:
     """Small wrapper around subprocess.run with cs-proxy defaults."""
 
-    default_timeout: int = 30
+    default_timeout: Optional[int] = 30
     dry_run: bool = False
     base_env: Optional[Mapping[str, str]] = None
     redacted_values: Sequence[str] = field(default_factory=tuple)
+
+    @staticmethod
+    def _looks_sensitive_env_key(key: str) -> bool:
+        upper = key.upper()
+        return any(
+            marker in upper
+            for marker in ("TOKEN", "PASSWORD", "SECRET", "PRIVATE_KEY", "API_KEY", "AUTH")
+        )
+
+    def _redact_text(self, value: str) -> str:
+        shown = value
+        for secret in (v for v in self.redacted_values if v):
+            shown = shown.replace(secret, "***")
+        return shown
 
     def _merged_env(self, env: Optional[Mapping[str, str]] = None) -> Optional[dict[str, str]]:
         if self.base_env is None and env is None:
@@ -39,8 +55,23 @@ class CommandRunner:
         parts = []
         redacted = {v for v in self.redacted_values if v}
         for part in cmd:
-            parts.append("***" if part in redacted else str(part))
+            shown = str(part)
+            for value in redacted:
+                shown = shown.replace(value, "***")
+            parts.append(shown)
         return " ".join(parts)
+
+    def _display_env(self, env: Optional[Mapping[str, str]]) -> str:
+        if not env:
+            return ""
+        shown = []
+        for key in sorted(env):
+            value = env[key]
+            if self._looks_sensitive_env_key(key):
+                shown.append(f"{key}=***")
+            else:
+                shown.append(f"{key}={self._redact_text(str(value))}")
+        return " ".join(shown)
 
     def run(
         self,
@@ -49,14 +80,17 @@ class CommandRunner:
         check: bool = False,
         capture_output: bool = True,
         text: bool = True,
-        timeout: Optional[int] = None,
+        timeout: object = _DEFAULT_TIMEOUT,
         env: Optional[Mapping[str, str]] = None,
         input=None,
         **kwargs,
     ) -> subprocess.CompletedProcess:
         """Run a command with consistent defaults."""
         logger = get_logger()
+        merged_env = self._merged_env(env)
         logger.debug(f"Running: {self._display_cmd(cmd)}")
+        if env:
+            logger.debug(f"With env: {self._display_env(env)}")
 
         if self.dry_run:
             return subprocess.CompletedProcess(list(cmd), 0, stdout="", stderr="")
@@ -66,8 +100,8 @@ class CommandRunner:
             check=check,
             capture_output=capture_output,
             text=text,
-            timeout=self.default_timeout if timeout is None else timeout,
-            env=self._merged_env(env),
+            timeout=self.default_timeout if timeout is _DEFAULT_TIMEOUT else timeout,
+            env=merged_env,
             input=input,
             **kwargs,
         )

--- a/csproxy/serve.py
+++ b/csproxy/serve.py
@@ -115,11 +115,12 @@ def _ssh(gh: GitHubManager, cs_name: str, command: str,
         CompletedProcess result
     """
     cmd = ['gh', 'codespace', 'ssh', '--codespace', cs_name, '--', command]
-    return subprocess.run(
+    return gh.runner.run(
         cmd,
         input=stdin,
         capture_output=True,
-        timeout=30
+        text=False,
+        timeout=30,
     )
 
 
@@ -141,11 +142,12 @@ def _upload_script(gh: GitHubManager, cs_name: str,
     _validate_remote_path(remote_path)
     cmd = ['gh', 'codespace', 'ssh', '--codespace', cs_name,
            '--', f'cat > {shlex.quote(remote_path)}']
-    result = subprocess.run(
+    result = gh.runner.run(
         cmd,
         input=content.encode(),
         capture_output=True,
-        timeout=30
+        text=False,
+        timeout=30,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -179,10 +181,11 @@ def _upload_file(gh: GitHubManager, cs_name: str,
     content = local_path.read_bytes()
     cmd = ['gh', 'codespace', 'ssh', '--codespace', cs_name,
            '--', f'cat > {shlex.quote(remote_path)}']
-    result = subprocess.run(
+    result = gh.runner.run(
         cmd,
         input=content,
         capture_output=True,
+        text=False,
         timeout=60
     )
     if result.returncode != 0:
@@ -219,7 +222,7 @@ def _setup_server_environment(gh: GitHubManager, cs_name: str, port: int) -> Non
 
     # Kill local port forward processes
     try:
-        subprocess.run(
+        gh.runner.run(
             ['pkill', '-f', f'gh codespace ports forward {shlex.quote(str(port))}'],
             capture_output=True
         )
@@ -315,8 +318,10 @@ def _tail_remote_logs(gh: GitHubManager, cs_name: str, new_only: bool = False) -
     """
     tail_cmd = 'tail -n 0 -f /tmp/serve/server.log' if new_only else 'tail -f /tmp/serve/server.log'
     try:
-        subprocess.run(
-            ['gh', 'codespace', 'ssh', '--codespace', cs_name, '--', tail_cmd]
+        gh.runner.run(
+            ['gh', 'codespace', 'ssh', '--codespace', cs_name, '--', tail_cmd],
+            capture_output=False,
+            timeout=None,
         )
     except KeyboardInterrupt:
         pass  # Normal exit
@@ -352,10 +357,11 @@ def _download_captures(gh: GitHubManager, cs_name: str) -> None:
         remote_path = f"/tmp/serve/captures/{filename}"
         local_path = Path(filename)
 
-        dl_result = subprocess.run(
+        dl_result = gh.runner.run(
             ['gh', 'codespace', 'ssh', '--codespace', cs_name,
              '--', f'cat {shlex.quote(remote_path)}'],
             capture_output=True,
+            text=False,
             timeout=30
         )
 
@@ -732,7 +738,7 @@ def stop_server(port: int, gh: GitHubManager, config: Config = None) -> None:
     _ssh(gh, cs_name, "pkill -f 'python3.*csproxy_' 2>/dev/null || true")
 
     try:
-        subprocess.run(
+        gh.runner.run(
             ['pkill', '-f', f'gh codespace ports forward {shlex.quote(str(port))}'],
             capture_output=True
         )
@@ -772,7 +778,7 @@ def clean_all(gh: GitHubManager, config: Config = None) -> None:
 
     logger.info("Killing local port forwards...")
     try:
-        subprocess.run(['pkill', '-f', 'gh codespace ports forward'], capture_output=True)
+        gh.runner.run(['pkill', '-f', 'gh codespace ports forward'], capture_output=True)
     except FileNotFoundError:
         pass
 

--- a/csproxy/state.py
+++ b/csproxy/state.py
@@ -4,23 +4,17 @@ from __future__ import annotations
 Lightweight JSON-based state management for csproxy.
 
 Replaces fragile flat PID files with a single atomic state.json.
-All writes are atomic (tempfile + os.replace) and guarded by a
-spinlock (os.O_CREAT|os.O_EXCL) with stale-lock detection.
-
-Locking notes:
-- os.O_CREAT | os.O_EXCL is atomic on POSIX and on Windows NTFS.
-- On Windows network drives (SMB) the atomicity guarantee may be weaker,
-  so we combine it with mtime-based stale-lock detection as a fallback.
-- The lock file contains the PID of the holder. If that process is dead
-  (or the lock file is older than 30s), we force-break it.
+All writes are atomic (tempfile + os.replace) and guarded by portalocker
+when installed, with a stdlib advisory-lock fallback.
 """
 
 import json
 import os
 import tempfile
-import time
 from pathlib import Path
 from typing import Any, Optional
+
+from .locking import file_lock
 
 
 def _pid_exists(pid: int) -> bool:
@@ -105,67 +99,23 @@ class State:
             Path(tmp.name).unlink(missing_ok=True)
             raise
 
-    def _acquire_lock(self, timeout: float = 5.0) -> None:
-        """
-        Acquire an advisory lock using atomic file creation.
-
-        Uses os.O_CREAT | os.O_EXCL which is atomic on POSIX and Windows NTFS.
-        If the lock file already exists, we check whether the owning process is
-        still alive (via the PID stored inside). Dead locks are force-broken.
-        As a fallback for network drives where O_EXCL may be unreliable, locks
-        older than 30 seconds are also considered stale.
-        """
-        start = time.time()
-        my_pid = os.getpid()
-        while True:
-            try:
-                fd = os.open(
-                    str(self._lock_path),
-                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                )
-                os.write(fd, str(my_pid).encode())
-                os.close(fd)
-                return
-            except FileExistsError:
-                # Stale lock detection: by PID and by mtime
-                try:
-                    lock_pid = int(self._lock_path.read_text().strip())
-                    stale_by_age = (
-                        time.time() - self._lock_path.stat().st_mtime > 30
-                    )
-                    if lock_pid != my_pid and (not _pid_exists(lock_pid) or stale_by_age):
-                        self._lock_path.unlink(missing_ok=True)
-                        continue
-                except (ValueError, OSError):
-                    self._lock_path.unlink(missing_ok=True)
-                    continue
-
-                if time.time() - start > timeout:
-                    raise TimeoutError(
-                        f"Could not acquire state lock ({self._lock_path}). "
-                        "Another cs-proxy process may be running."
-                    )
-                time.sleep(0.05)
-
-    def _release_lock(self) -> None:
-        """Release the advisory lock."""
-        self._lock_path.unlink(missing_ok=True)
-
     def load(self) -> dict:
         """Load state under lock."""
-        self._acquire_lock()
-        try:
+        with file_lock(self._lock_path):
             return self._read()
-        finally:
-            self._release_lock()
 
     def save(self, data: dict) -> None:
         """Save state under lock."""
-        self._acquire_lock()
-        try:
+        with file_lock(self._lock_path):
             self._write(data)
-        finally:
-            self._release_lock()
+
+    def _update_locked(self, updater):
+        """Run a read-modify-write operation under a single file lock."""
+        with file_lock(self._lock_path):
+            data = self._read()
+            result = updater(data)
+            self._write(data)
+            return result
 
     # ------------------------------------------------------------------
     # Public API
@@ -177,27 +127,26 @@ class State:
 
         Call this on every CLI startup so stale state from previous runs is cleaned up.
         """
-        data = self.load()
-        changed = False
-        crashed = []
-        for t in data.get("tunnels", []):
-            if t.get("status") in ("stopped", "crashed", "dead"):
-                continue
-            pid = t.get("pid")
-            alive = _pid_exists(pid) if pid else False
-            if not alive:
-                t["status"] = "crashed"
-                crashed.append(t)
-                changed = True
-        if changed:
-            self.save(data)
-        return crashed
+        def updater(data):
+            crashed = []
+            for t in data.get("tunnels", []):
+                if t.get("status") in ("stopped", "crashed", "dead"):
+                    continue
+                pid = t.get("pid")
+                alive = _pid_exists(pid) if pid else False
+                if not alive:
+                    t["status"] = "crashed"
+                    crashed.append(t)
+            return crashed
+
+        return self._update_locked(updater)
 
     def clear_all(self) -> None:
         """Remove all tunnels from state."""
-        data = self.load()
-        data["tunnels"] = []
-        self.save(data)
+        def updater(data):
+            data["tunnels"] = []
+
+        self._update_locked(updater)
 
     def get_tunnels(
         self, kind: Optional[str] = None, status: Optional[str] = None
@@ -220,33 +169,36 @@ class State:
 
     def add_tunnel(self, **fields: Any) -> None:
         """Add or replace a tunnel entry by its 'id'."""
-        data = self.load()
-        tunnels = [t for t in data.get("tunnels", []) if t.get("id") != fields.get("id")]
-        tunnels.append(fields)
-        data["tunnels"] = tunnels
-        self.save(data)
+        def updater(data):
+            tunnels = [t for t in data.get("tunnels", []) if t.get("id") != fields.get("id")]
+            tunnels.append(fields)
+            data["tunnels"] = tunnels
+
+        self._update_locked(updater)
 
     def remove_tunnel(
         self, port: Optional[int] = None, tunnel_id: Optional[str] = None
     ) -> None:
         """Remove a tunnel by port and/or tunnel_id."""
-        data = self.load()
-        tunnels = data.get("tunnels", [])
-        if port is not None:
-            tunnels = [t for t in tunnels if t.get("port") != port]
-        if tunnel_id is not None:
-            tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
-        data["tunnels"] = tunnels
-        self.save(data)
+        def updater(data):
+            tunnels = data.get("tunnels", [])
+            if port is not None:
+                tunnels = [t for t in tunnels if t.get("port") != port]
+            if tunnel_id is not None:
+                tunnels = [t for t in tunnels if t.get("id") != tunnel_id]
+            data["tunnels"] = tunnels
+
+        self._update_locked(updater)
 
     def update_tunnel(self, port: int, **kwargs: Any) -> None:
         """Update fields for the tunnel matching the given port."""
-        data = self.load()
-        for t in data.get("tunnels", []):
-            if t.get("port") == port:
-                t.update(kwargs)
-                break
-        self.save(data)
+        def updater(data):
+            for t in data.get("tunnels", []):
+                if t.get("port") == port:
+                    t.update(kwargs)
+                    break
+
+        self._update_locked(updater)
 
     def mark_crashed(self, port: int) -> None:
         """Convenience wrapper to mark a tunnel as crashed."""
@@ -260,17 +212,20 @@ class State:
 
         Returns True if the circuit breaker tripped (status set to 'dead').
         """
-        data = self.load()
-        for t in data.get("tunnels", []):
-            if t.get("port") == port:
-                now = int(time.time())
-                last = t.get("last_failure", 0)
-                if now - last > window:
-                    t["failures"] = 0
-                t["failures"] = t.get("failures", 0) + 1
-                t["last_failure"] = now
-                if t["failures"] >= max_failures:
-                    t["status"] = "dead"
-                self.save(data)
-                return t["status"] == "dead"
-        return False
+        def updater(data):
+            for t in data.get("tunnels", []):
+                if t.get("port") == port:
+                    import time
+
+                    now = int(time.time())
+                    last = t.get("last_failure", 0)
+                    if now - last > window:
+                        t["failures"] = 0
+                    t["failures"] = t.get("failures", 0) + 1
+                    t["last_failure"] = now
+                    if t["failures"] >= max_failures:
+                        t["status"] = "dead"
+                    return t["status"] == "dead"
+            return False
+
+        return self._update_locked(updater)

--- a/csproxy/templates.py
+++ b/csproxy/templates.py
@@ -254,19 +254,27 @@ sudo apt-get install -y wireguard-tools iptables socat --no-install-recommends 2
 echo "[*] Creating WireGuard config..."
 sudo mkdir -p /etc/wireguard
 
-sudo tee /etc/wireguard/wg0.conf > /dev/null << 'WGCONF'
+IFS= read -r REMOTE_PRIVATE_KEY
+IFS= read -r LOCAL_PUBLIC_KEY
+if [ -z "$REMOTE_PRIVATE_KEY" ] || [ -z "$LOCAL_PUBLIC_KEY" ]; then
+    echo "[!] Missing WireGuard key material on stdin" >&2
+    exit 1
+fi
+
+sudo tee /etc/wireguard/wg0.conf > /dev/null << WGCONF
 [Interface]
-PrivateKey = {remote_private_key}
+PrivateKey = ${{REMOTE_PRIVATE_KEY}}
 Address = {wg_remote_ip}
 ListenPort = {wg_port}
 PostUp = iptables -I FORWARD 1 -i wg0 -o eth0 -j ACCEPT; iptables -I FORWARD 2 -i eth0 -o wg0 -m state --state RELATED,ESTABLISHED -j ACCEPT; iptables -t nat -A POSTROUTING -s {wg_network} -o eth0 -j MASQUERADE; sysctl -w net.ipv4.ip_forward=1
 PostDown = iptables -D FORWARD -i wg0 -o eth0 -j ACCEPT; iptables -D FORWARD -i eth0 -o wg0 -m state --state RELATED,ESTABLISHED -j ACCEPT; iptables -t nat -D POSTROUTING -s {wg_network} -o eth0 -j MASQUERADE || true
 
 [Peer]
-PublicKey = {local_public_key}
+PublicKey = ${{LOCAL_PUBLIC_KEY}}
 AllowedIPs = {local_ip_host}/32
 WGCONF
 
+unset REMOTE_PRIVATE_KEY LOCAL_PUBLIC_KEY
 sudo chmod 600 /etc/wireguard/wg0.conf
 
 echo "[*] Stopping any existing WireGuard..."

--- a/csproxy/tools.py
+++ b/csproxy/tools.py
@@ -23,6 +23,7 @@ import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from .runner import CommandRunner
 from .state import State
 from .utils import Config, get_logger
 
@@ -30,6 +31,10 @@ VERSION = "1.0.0"
 
 # Cache for proxy health checks: {(host, port): (timestamp, healthy)}
 _CHECK_CACHE: Dict[Tuple[str, int], Tuple[float, bool]] = {}
+
+
+def _run(cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
+    return CommandRunner().run(cmd, **kwargs)
 
 
 # =============================================================================
@@ -97,7 +102,7 @@ def check_proxy(
                 print("    Start with: cs-proxy start")
             return healthy
 
-    result = subprocess.run(
+    result = _run(
         [
             'curl', '-s', '--connect-timeout', '2',
             '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me',
@@ -270,8 +275,9 @@ def pcurl(
     port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
-    return subprocess.run(
+    return _run(
         ['curl', '--socks5-hostname', f'{host}:{port}'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -302,8 +308,9 @@ def pwget(
     proxychains_conf = config.config_dir / 'proxychains.conf'
     if not check_proxy(host, port):
         return 1
-    return subprocess.run(
+    return _run(
         ['proxychains4', '-q', '-f', str(proxychains_conf), 'wget'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -340,8 +347,9 @@ def pnmap(
     if not check_proxy(host, port):
         return 1
     args = _sanitize_nmap_args(args)
-    return subprocess.run(
+    return _run(
         ['proxychains4', '-q', '-f', str(proxychains_conf), 'nmap'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -372,9 +380,10 @@ def pnuclei(
     if not check_proxy(host, port):
         return 1
     env = _proxy_env(host, port)
-    return subprocess.run(
+    return _run(
         ['nuclei'] + args,
         env=env,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -457,8 +466,9 @@ def pffuf(
     if not check_proxy(host, port):
         return 1
     args = _sanitize_ffuf_args(args)
-    return subprocess.run(
+    return _run(
         ['ffuf', '-x', f'socks5://{host}:{port}'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -488,8 +498,9 @@ def phttpx(
     port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
-    return subprocess.run(
+    return _run(
         ['httpx', '-proxy', f'socks5://{host}:{port}'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -519,8 +530,9 @@ def psqlmap(
     port = port or _get_proxy_port(config)
     if not check_proxy(host, port):
         return 1
-    return subprocess.run(
+    return _run(
         ['sqlmap', f'--proxy=socks5://{host}:{port}'] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -557,8 +569,9 @@ def pcs(
     if args and not shutil.which(args[0]):
         logger.error(f"Command not found: {args[0]}")
         return 127
-    return subprocess.run(
+    return _run(
         ['proxychains4', '-q', '-f', str(proxychains_conf)] + args,
+        capture_output=False,
         timeout=timeout,
     ).returncode
 
@@ -583,7 +596,7 @@ def ipcheck(
     port = port or _get_proxy_port(config)
 
     # Direct IP
-    result = subprocess.run(
+    result = _run(
         ['curl', '-s', '--connect-timeout', '5', 'https://ifconfig.me'],
         capture_output=True,
         text=True,
@@ -592,7 +605,7 @@ def ipcheck(
     direct_ip = result.stdout.strip() if result.returncode == 0 else 'timeout'
 
     # Proxied IP
-    result = subprocess.run(
+    result = _run(
         [
             'curl', '-s', '--connect-timeout', '5',
             '--socks5-hostname', f'{host}:{port}', 'https://ifconfig.me',
@@ -656,9 +669,10 @@ def psub(
         ['subfinder', '-d', domain, '-silent'],
         stdout=subprocess.PIPE,
     )
-    result = subprocess.run(
+    result = _run(
         ['httpx', '-proxy', f'socks5://{host}:{port}', '-silent'],
         stdin=subfinder.stdout,
+        capture_output=False,
         timeout=timeout,
     )
     subfinder.wait()

--- a/csproxy/tunnel.py
+++ b/csproxy/tunnel.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
+from .runner import CommandRunner
 from .state import State
 from .utils import Config, ProxyError, SSHTunnelError, get_logger
 
@@ -35,10 +36,13 @@ class SSHTunnel:
         self.codespace_name = codespace_name
         self.port = port or config.socks_port
         self.logger = get_logger()
+        self.runner = CommandRunner()
         self.pid_file = config.config_dir / f'proxy{pid_suffix}.pid'
         self.stop_file = config.config_dir / f'proxy{pid_suffix}.pid.stop'
         self.log_file = config.config_dir / f'proxy{pid_suffix}.log'
         self.spec_file = config.config_dir / 'workers' / f'{self.port}.json'
+        self.ready_file = self.spec_file.with_suffix('.ready')
+        self.status_file = self.spec_file.with_suffix('.status.json')
         self.state = State(config.config_dir)
         self.tunnel_id = f'ssh-{self.port}'
         self._process: Optional[subprocess.Popen] = None
@@ -64,6 +68,8 @@ class SSHTunnel:
 
         self.logger.info(f"Starting SOCKS5 proxy on port {self.port}...")
         self.stop_file.unlink(missing_ok=True)
+        self.ready_file.unlink(missing_ok=True)
+        self.status_file.unlink(missing_ok=True)
         self.spec_file.parent.mkdir(parents=True, exist_ok=True)
 
         ssh_args = [
@@ -84,8 +90,11 @@ class SSHTunnel:
             'gh_cmd': gh_cmd,
             'log_file': str(self.log_file),
             'stop_file': str(self.stop_file),
+            'ready_file': str(self.ready_file),
+            'status_file': str(self.status_file),
             'reconnect_delay': self.config.reconnect_delay,
             'max_reconnect_delay': self.config.max_reconnect_delay,
+            'log_max_bytes': self.config.worker_log_max_bytes,
         }
         self.spec_file.write_text(json.dumps(spec))
 
@@ -111,29 +120,7 @@ class SSHTunnel:
         self._process = proc
         self._write_pid(proc.pid)
 
-        # Quick verification: ensure the worker didn't crash immediately
-        # and that it still has its spec file (proves it started reading it)
-        time.sleep(0.3)
-        if proc.poll() is not None:
-            stderr_text = ""
-            try:
-                if stderr_file.exists():
-                    stderr_text = stderr_file.read_text().strip()
-                    stderr_file.unlink(missing_ok=True)
-            except OSError:
-                pass
-            self.spec_file.unlink(missing_ok=True)
-            msg = (
-                f"Tunnel worker exited immediately with code {proc.returncode}. "
-                f"Check that 'python -m csproxy._worker' is executable."
-            )
-            if stderr_text:
-                msg += f" Worker stderr: {stderr_text[:500]}"
-            raise SSHTunnelError(msg)
-        if not self.spec_file.exists():
-            raise SSHTunnelError(
-                "Tunnel worker started but spec file was cleaned up unexpectedly."
-            )
+        self._wait_for_worker_ready(proc, stderr_file, timeout=2.0)
 
         self.state.add_tunnel(
             id=self.tunnel_id,
@@ -190,9 +177,17 @@ class SSHTunnel:
             except (ProcessLookupError, PermissionError):
                 pass
 
+        # The worker may be killed while its child gh/ssh process is still
+        # holding the dynamic SOCKS listener. Make stop idempotently clear the
+        # port so a successful stop means the proxy is actually gone.
+        self._kill_port_holders()
+
         self.pid_file.unlink(missing_ok=True)
+        self.stop_file.unlink(missing_ok=True)
         self.spec_file.unlink(missing_ok=True)
         self.spec_file.with_suffix('.stderr').unlink(missing_ok=True)
+        self.ready_file.unlink(missing_ok=True)
+        self.status_file.unlink(missing_ok=True)
         self.state.remove_tunnel(port=self.port)
         self.logger.info("Proxy stopped")
 
@@ -222,6 +217,8 @@ class SSHTunnel:
         self.stop_file.unlink(missing_ok=True)
         self.spec_file.unlink(missing_ok=True)
         self.spec_file.with_suffix('.stderr').unlink(missing_ok=True)
+        self.ready_file.unlink(missing_ok=True)
+        self.status_file.unlink(missing_ok=True)
         self.state.remove_tunnel(port=self.port)
 
     def _kill_port_holders(self) -> None:
@@ -229,7 +226,7 @@ class SSHTunnel:
         try:
             if sys.platform == 'darwin':
                 # lsof -ti:port gives PIDs
-                result = subprocess.run(
+                result = self.runner.run(
                     ['lsof', '-ti', f':{self.port}'],
                     capture_output=True, text=True, timeout=5
                 )
@@ -240,7 +237,7 @@ class SSHTunnel:
                         except (ValueError, ProcessLookupError, PermissionError):
                             pass
             elif sys.platform == 'linux':
-                result = subprocess.run(
+                result = self.runner.run(
                     ['fuser', '-k', f'{self.port}/tcp'],
                     capture_output=True, timeout=5
                 )
@@ -271,17 +268,20 @@ class SSHTunnel:
         """Remove stale PID files and state entries for dead processes."""
         self.pid_file.unlink(missing_ok=True)
         self.spec_file.unlink(missing_ok=True)
+        self.ready_file.unlink(missing_ok=True)
+        self.status_file.unlink(missing_ok=True)
         self.state.remove_tunnel(port=self.port)
 
     def health_check(self, timeout: int = 5) -> bool:
         """Verify the SOCKS5 proxy is responding."""
-        result = subprocess.run(
+        health_url = self.config.health_check_url
+        result = self.runner.run(
             [
                 'curl', '-s',
                 '--connect-timeout', str(timeout),
                 '--max-time', str(timeout + 2),
                 '--socks5-hostname', f'127.0.0.1:{self.port}',
-                'https://ifconfig.me'
+                health_url,
             ],
             capture_output=True,
             timeout=timeout + 5
@@ -302,18 +302,62 @@ class SSHTunnel:
 
     def get_exit_ip(self) -> Optional[str]:
         """Get the exit IP address through the proxy."""
-        result = subprocess.run(
+        health_url = self.config.health_check_url
+        result = self.runner.run(
             [
                 'curl', '-s',
                 '--connect-timeout', '5',
                 '--socks5-hostname', f'127.0.0.1:{self.port}',
-                'https://ifconfig.me'
+                health_url,
             ],
             capture_output=True,
             text=True,
             timeout=10
         )
         return result.stdout.strip() if result.returncode == 0 else None
+
+    def _wait_for_worker_ready(
+        self,
+        proc: subprocess.Popen,
+        stderr_file: Path,
+        *,
+        timeout: float,
+    ) -> None:
+        """Wait for the detached worker to acknowledge it loaded its spec."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                stderr_text = ""
+                try:
+                    if stderr_file.exists():
+                        stderr_text = stderr_file.read_text().strip()
+                        stderr_file.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                self.spec_file.unlink(missing_ok=True)
+                self.ready_file.unlink(missing_ok=True)
+                self.status_file.unlink(missing_ok=True)
+                msg = (
+                    f"Tunnel worker exited immediately with code {proc.returncode}. "
+                    f"Check that 'python -m csproxy._worker' is executable."
+                )
+                if stderr_text:
+                    msg += f" Worker stderr: {stderr_text[:500]}"
+                raise SSHTunnelError(msg)
+            if self.ready_file.exists():
+                return
+            time.sleep(0.05)
+        self.spec_file.unlink(missing_ok=True)
+        status_text = ""
+        try:
+            if self.status_file.exists():
+                status_text = self.status_file.read_text().strip()[:500]
+        except OSError:
+            status_text = ""
+        message = "Tunnel worker did not signal readiness after loading its spec."
+        if status_text:
+            message += f" Worker status: {status_text}"
+        raise SSHTunnelError(message)
 
     def _write_pid(self, pid: int) -> None:
         """Write PID to PID file."""
@@ -345,7 +389,7 @@ class HTTPProxyManager:
     def _install_tinyproxy(self) -> None:
         """Attempt to install tinyproxy via apt-get."""
         self.logger.warning("tinyproxy not installed. Installing...")
-        result = subprocess.run(
+        result = CommandRunner().run(
             ['sudo', 'apt-get', 'install', '-y', 'tinyproxy'],
             capture_output=True
         )
@@ -387,9 +431,10 @@ Upstream socks5 127.0.0.1:{self.config.socks_port}
 
         self._write_config()
 
-        result = subprocess.run(
+        result = CommandRunner().run(
             ['tinyproxy', '-c', str(self.conf_file)],
-            capture_output=True
+            capture_output=True,
+            text=False,
         )
 
         if result.returncode != 0:
@@ -402,6 +447,6 @@ Upstream socks5 127.0.0.1:{self.config.socks_port}
     def stop(self) -> None:
         """Stop tinyproxy if running."""
         try:
-            subprocess.run(['pkill', 'tinyproxy'], capture_output=True)
+            CommandRunner().run(['pkill', 'tinyproxy'], capture_output=True)
         except FileNotFoundError:
             pass

--- a/csproxy/utils/config.py
+++ b/csproxy/utils/config.py
@@ -31,6 +31,8 @@ class _ConfigData:
     codespace_name: str = ""
     reconnect_delay: int = 5
     max_reconnect_delay: int = 300
+    health_check_url: str = "https://ifconfig.me"
+    worker_log_max_bytes: int = 2_000_000
     dns_proxy: bool = False
     verbose: bool = False
     cloudflare_api_token: str = ""
@@ -68,6 +70,10 @@ class _ConfigData:
             raise ValueError(f"reconnect_delay must be >= 1, got {self.reconnect_delay}")
         if self.max_reconnect_delay < self.reconnect_delay:
             raise ValueError("max_reconnect_delay must be >= reconnect_delay")
+        if not self.health_check_url.startswith(("http://", "https://")):
+            raise ValueError("health_check_url must start with http:// or https://")
+        if self.worker_log_max_bytes < 0:
+            raise ValueError("worker_log_max_bytes must be >= 0")
 
     def set_field(self, key: str, value: Any) -> None:
         """Set a field with full schema re-validation."""
@@ -96,6 +102,8 @@ class Config:
         "codespace_name": "",
         "reconnect_delay": 5,
         "max_reconnect_delay": 300,
+        "health_check_url": "https://ifconfig.me",
+        "worker_log_max_bytes": 2_000_000,
         "dns_proxy": False,
         "verbose": False,
         "cloudflare_api_token": "",
@@ -144,6 +152,8 @@ class Config:
             "CODESPACE_NAME": ("codespace_name", str),
             "RECONNECT_DELAY": ("reconnect_delay", int),
             "MAX_RECONNECT_DELAY": ("max_reconnect_delay", int),
+            "HEALTH_CHECK_URL": ("health_check_url", str),
+            "WORKER_LOG_MAX_BYTES": ("worker_log_max_bytes", int),
             "DNS_PROXY": ("dns_proxy", lambda x: x.lower() in ("true", "1", "yes")),
             "VERBOSE": ("verbose", lambda x: x.lower() in ("true", "1", "yes")),
             "NUM_PROXIES": ("num_proxies", int),
@@ -279,6 +289,14 @@ class Config:
         return self._data.max_reconnect_delay
 
     @property
+    def health_check_url(self) -> str:
+        return self._data.health_check_url
+
+    @property
+    def worker_log_max_bytes(self) -> int:
+        return self._data.worker_log_max_bytes
+
+    @property
     def dns_proxy(self) -> bool:
         return self._data.dns_proxy
 
@@ -330,6 +348,8 @@ locations: []
 
 reconnect_delay: 5
 max_reconnect_delay: 300
+health_check_url: "https://ifconfig.me"
+worker_log_max_bytes: 2000000
 
 # =============================================================================
 # Advanced Settings

--- a/csproxy/wg_monitor.py
+++ b/csproxy/wg_monitor.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 from typing import Optional
 
+from .runner import CommandRunner
 from .utils import get_logger
 from .wg_constants import WG_INTERFACE
 
@@ -38,7 +39,7 @@ def monitor_traffic(mode: Optional[str], interface: str = WG_INTERFACE) -> None:
     logger = get_logger()
     _check_root()
 
-    result = subprocess.run(['ip', 'link', 'show', interface], capture_output=True)
+    result = CommandRunner().run(['ip', 'link', 'show', interface], capture_output=True)
     if result.returncode != 0:
         raise RuntimeError(f"WireGuard interface {interface} not found. Run 'cs-wg up' first.")
 
@@ -101,7 +102,10 @@ def monitor_traffic(mode: Optional[str], interface: str = WG_INTERFACE) -> None:
 
         elif mode == 'all':
             logger.info("Monitoring all traffic (summary)...")
-            subprocess.run(['tcpdump', '-i', interface, '-n', '-l', '-t', '-q'])
+            CommandRunner(default_timeout=None).run(
+                ['tcpdump', '-i', interface, '-n', '-l', '-t', '-q'],
+                capture_output=False,
+            )
 
         elif mode == 'leak':
             logger.info("Monitoring for traffic leaks on eth0...")

--- a/csproxy/wg_routes.py
+++ b/csproxy/wg_routes.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from .runner import CommandRunner
 from .utils import Config, get_logger
 from .wg_constants import WG_INTERFACE
 
@@ -38,6 +39,10 @@ _BYPASS_ROUTES = [
 ]
 
 
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return CommandRunner().run(cmd, **kwargs)
+
+
 def _check_root() -> None:
     """Raise RuntimeError if not running as root."""
     if os.geteuid() != 0:
@@ -52,7 +57,7 @@ def add_route(target: str, interface: str = WG_INTERFACE) -> None:
         raise ValueError("Usage: cs-wg route add <ip/cidr or domain>")
 
     if not re.match(r'^\d+\.\d+\.\d+\.\d+', target):
-        result = subprocess.run(['dig', '+short', target], capture_output=True, text=True)
+        result = _run(['dig', '+short', target], capture_output=True, text=True)
         ip = result.stdout.strip().splitlines()[0] if result.stdout.strip() else ''
         if not ip:
             raise RuntimeError(f"Could not resolve: {target}")
@@ -62,7 +67,7 @@ def add_route(target: str, interface: str = WG_INTERFACE) -> None:
     if '/' not in target:
         target = f"{target}/32"
 
-    result = subprocess.run(['ip', 'route', 'add', target, 'dev', interface], capture_output=True)
+    result = _run(['ip', 'route', 'add', target, 'dev', interface], capture_output=True)
     if result.returncode != 0:
         logger.warning(f"Route may already exist: {target}")
     else:
@@ -79,7 +84,7 @@ def del_route(target: str, interface: str = WG_INTERFACE) -> None:
     if '/' not in target:
         target = f"{target}/32"
 
-    subprocess.run(['ip', 'route', 'del', target, 'dev', interface], capture_output=True)
+    _run(['ip', 'route', 'del', target, 'dev', interface], capture_output=True)
     logger.info(f"Removed route: {target}")
 
 
@@ -93,7 +98,7 @@ def route_all(config: Config, interface: str = WG_INTERFACE) -> None:
     logger = get_logger()
     _check_root()
 
-    result = subprocess.run(['ip', 'link', 'show', interface], capture_output=True)
+    result = _run(['ip', 'link', 'show', interface], capture_output=True)
     if result.returncode != 0:
         raise RuntimeError(f"WireGuard interface {interface} not found. Run 'cs-wg up' first.")
 
@@ -103,7 +108,7 @@ def route_all(config: Config, interface: str = WG_INTERFACE) -> None:
     if confirm not in ('y', 'yes'):
         return
 
-    result = subprocess.run(['ip', 'route'], capture_output=True, text=True)
+    result = _run(['ip', 'route'], capture_output=True, text=True)
     default_line = next((l for l in result.stdout.splitlines() if l.startswith('default')), '')
     parts = default_line.split()
     try:
@@ -125,32 +130,32 @@ def route_all(config: Config, interface: str = WG_INTERFACE) -> None:
     except OSError:
         pass
 
-    ipv6_result = subprocess.run(['cat', '/proc/sys/net/ipv6/conf/all/disable_ipv6'],
-                                  capture_output=True, text=True)
+    ipv6_result = _run(['cat', '/proc/sys/net/ipv6/conf/all/disable_ipv6'],
+                       capture_output=True, text=True)
     (wg_dir / 'ipv6_state.backup').write_text(ipv6_result.stdout.strip() or '1')
     logger.info("Disabling IPv6 (tunnel is IPv4 only)...")
     for key in ['net.ipv6.conf.all.disable_ipv6', 'net.ipv6.conf.default.disable_ipv6',
                 'net.ipv6.conf.lo.disable_ipv6']:
-        subprocess.run(['sysctl', '-w', f'{key}=1'], capture_output=True)
+        _run(['sysctl', '-w', f'{key}=1'], capture_output=True)
 
     logger.info("Adding bypass routes for GitHub/Azure...")
     for cidr in _BYPASS_ROUTES:
-        subprocess.run(['ip', 'route', 'add', cidr, 'via', default_gw,
-                        'dev', default_dev], capture_output=True)
+        _run(['ip', 'route', 'add', cidr, 'via', default_gw,
+              'dev', default_dev], capture_output=True)
 
-    kernel_result = subprocess.run(['ip', 'route'], capture_output=True, text=True)
+    kernel_result = _run(['ip', 'route'], capture_output=True, text=True)
     for line in kernel_result.stdout.splitlines():
         if 'proto kernel' in line and default_dev in line:
             local_net = line.split()[0]
             if local_net and local_net != 'default':
                 logger.info(f"Preserving local network: {local_net}")
-                subprocess.run(['ip', 'route', 'add', local_net, 'via', default_gw,
-                                'dev', default_dev], capture_output=True)
+                _run(['ip', 'route', 'add', local_net, 'via', default_gw,
+                      'dev', default_dev], capture_output=True)
             break
 
     logger.info("Routing all traffic through tunnel...")
-    subprocess.run(['ip', 'route', 'add', '0.0.0.0/1', 'dev', interface], check=True)
-    subprocess.run(['ip', 'route', 'add', '128.0.0.0/1', 'dev', interface], check=True)
+    _run(['ip', 'route', 'add', '0.0.0.0/1', 'dev', interface], check=True)
+    _run(['ip', 'route', 'add', '128.0.0.0/1', 'dev', interface], check=True)
 
     logger.info("Setting DNS to use tunnel...")
     Path('/etc/resolv.conf').write_text("nameserver 1.1.1.1\nnameserver 8.8.8.8\n")
@@ -167,11 +172,11 @@ def route_restore(config: Config, interface: str = WG_INTERFACE) -> None:
 
     logger.info("Restoring default routing...")
 
-    subprocess.run(['ip', 'route', 'del', '0.0.0.0/1', 'dev', interface], capture_output=True)
-    subprocess.run(['ip', 'route', 'del', '128.0.0.0/1', 'dev', interface], capture_output=True)
+    _run(['ip', 'route', 'del', '0.0.0.0/1', 'dev', interface], capture_output=True)
+    _run(['ip', 'route', 'del', '128.0.0.0/1', 'dev', interface], capture_output=True)
 
     for cidr in _BYPASS_ROUTES:
-        subprocess.run(['ip', 'route', 'del', cidr], capture_output=True)
+        _run(['ip', 'route', 'del', cidr], capture_output=True)
 
     wg_dir = config.config_dir / 'wireguard'
     resolv_backup = wg_dir / 'resolv.conf.backup'
@@ -188,7 +193,7 @@ def route_restore(config: Config, interface: str = WG_INTERFACE) -> None:
             logger.info("Re-enabling IPv6...")
             for key in ['net.ipv6.conf.all.disable_ipv6', 'net.ipv6.conf.default.disable_ipv6',
                         'net.ipv6.conf.lo.disable_ipv6']:
-                subprocess.run(['sysctl', '-w', f'{key}=0'], capture_output=True)
+                _run(['sysctl', '-w', f'{key}=0'], capture_output=True)
         ipv6_backup.unlink()
 
     logger.info("Default routing restored")

--- a/csproxy/wg_setup.py
+++ b/csproxy/wg_setup.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Optional
 
 from .github import GitHubManager
+from .runner import CommandRunner
 from .templates import WG_REMOTE_SETUP_SCRIPT as _REMOTE_SETUP_SCRIPT
 from .utils import Config, get_logger
 
@@ -36,7 +37,7 @@ def _run_gh(args: list, sudo_user: Optional[str] = None,
         cmd = ['sudo', '-u', sudo_user, 'gh'] + args
     else:
         cmd = ['gh'] + args
-    return subprocess.run(cmd, **kwargs)
+    return CommandRunner().run(cmd, **kwargs)
 
 
 def _ensure_dirs(wg_dir: Path, config_dir: Path, sudo_user: Optional[str] = None) -> None:
@@ -53,8 +54,8 @@ def _ensure_dirs(wg_dir: Path, config_dir: Path, sudo_user: Optional[str] = None
         pass
 
     if os.geteuid() == 0 and sudo_user:
-        subprocess.run(['chown', '-R', f'{sudo_user}:{sudo_user}', str(config_dir)],
-                       capture_output=True)
+        CommandRunner().run(['chown', '-R', f'{sudo_user}:{sudo_user}', str(config_dir)],
+                            capture_output=True)
 
 
 def generate_keys(wg_dir: Path) -> None:
@@ -70,13 +71,14 @@ def generate_keys(wg_dir: Path) -> None:
     local_priv = wg_dir / 'local_private.key'
     local_pub = wg_dir / 'local_public.key'
     if not local_priv.exists():
-        result = subprocess.run(['wg', 'genkey'], capture_output=True, text=True, check=True)
+        runner = CommandRunner()
+        result = runner.run(['wg', 'genkey'], capture_output=True, text=True, check=True)
         private_key = result.stdout.strip()
         local_priv.write_text(private_key)
         local_priv.chmod(0o600)
 
-        result = subprocess.run(['wg', 'pubkey'], input=private_key,
-                                capture_output=True, text=True, check=True)
+        result = runner.run(['wg', 'pubkey'], input=private_key,
+                            capture_output=True, text=True, check=True)
         local_pub.write_text(result.stdout.strip())
         logger.info("Generated local keypair")
     else:
@@ -86,13 +88,14 @@ def generate_keys(wg_dir: Path) -> None:
     remote_priv = wg_dir / 'remote_private.key'
     remote_pub = wg_dir / 'remote_public.key'
     if not remote_priv.exists():
-        result = subprocess.run(['wg', 'genkey'], capture_output=True, text=True, check=True)
+        runner = CommandRunner()
+        result = runner.run(['wg', 'genkey'], capture_output=True, text=True, check=True)
         private_key = result.stdout.strip()
         remote_priv.write_text(private_key)
         remote_priv.chmod(0o600)
 
-        result = subprocess.run(['wg', 'pubkey'], input=private_key,
-                                capture_output=True, text=True, check=True)
+        result = runner.run(['wg', 'pubkey'], input=private_key,
+                            capture_output=True, text=True, check=True)
         remote_pub.write_text(result.stdout.strip())
         logger.info("Generated remote keypair")
     else:
@@ -264,20 +267,26 @@ def build_remote_setup_script(wg_dir: Path, remote_ip: str = _WG_REMOTE_IP,
 
     Equivalent to generate_remote_setup_script() in cs-wg.sh.
 
+    The script intentionally does not embed WireGuard private keys. Runtime key
+    material is sent over stdin by ``remote_setup_secret_payload``.
+
     Returns:
-        Complete Bash script content with keys embedded.
+        Complete Bash script content without private key material.
     """
-    remote_priv = (wg_dir / 'remote_private.key').read_text().strip()
-    local_pub = (wg_dir / 'local_public.key').read_text().strip()
     local_ip_host = local_ip.split('/')[0]
     remote_ip_host = remote_ip.split('/')[0]
 
     return _REMOTE_SETUP_SCRIPT.format(
-        remote_private_key=remote_priv,
         wg_remote_ip=remote_ip,
         wg_port=port,
         wg_network=network,
-        local_public_key=local_pub,
         local_ip_host=local_ip_host,
         remote_ip_host=remote_ip_host,
     )
+
+
+def remote_setup_secret_payload(wg_dir: Path) -> bytes:
+    """Build the stdin payload consumed by the remote setup script."""
+    remote_priv = (wg_dir / 'remote_private.key').read_text().strip()
+    local_pub = (wg_dir / 'local_public.key').read_text().strip()
+    return f"{remote_priv}\n{local_pub}\n".encode()

--- a/csproxy/wireguard.py
+++ b/csproxy/wireguard.py
@@ -27,6 +27,7 @@ from .wg_monitor import monitor_traffic  # noqa: F401
 from .wg_setup import (  # noqa: F401
     _check_root, _run_gh, _ensure_dirs, generate_keys,
     generate_local_config, build_remote_setup_script as _build_remote_setup_script,
+    remote_setup_secret_payload as _remote_setup_secret_payload,
     select_codespace as _select_codespace,
     ensure_codespace_running as _ensure_codespace_running,
 )
@@ -51,6 +52,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     """
     logger = get_logger()
     sudo_user = os.environ.get('SUDO_USER') if os.geteuid() == 0 else None
+    runner = gh.runner
 
     _check_root()
 
@@ -91,6 +93,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
 
     logger.info("Configuring WireGuard in Codespace (this takes ~30 seconds)...")
     script = _build_remote_setup_script(wg_dir)
+    secret_payload = _remote_setup_secret_payload(wg_dir)
 
     # Upload setup script via stdin
     setup_path = '/tmp/setup_wg.sh'
@@ -99,26 +102,31 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     if sudo_user and os.geteuid() == 0:
         gh_cmd = ['sudo', '-u', sudo_user] + gh_cmd
 
-    result = subprocess.run(gh_cmd, input=script.encode(), capture_output=True)
-    if result.returncode != 0:
-        raise RuntimeError(f"Failed to copy setup script to codespace: "
-                           f"{result.stderr.decode().strip()}")
+    copy_attempted = False
+    try:
+        copy_attempted = True
+        result = runner.run(gh_cmd, input=script, capture_output=True, text=True, timeout=60)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to copy setup script to codespace: "
+                               f"{str(result.stderr).strip()}")
 
-    run_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--', setup_path]
-    if sudo_user and os.geteuid() == 0:
-        run_cmd = ['sudo', '-u', sudo_user] + run_cmd
+        run_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--', setup_path]
+        if sudo_user and os.geteuid() == 0:
+            run_cmd = ['sudo', '-u', sudo_user] + run_cmd
 
-    result = subprocess.run(run_cmd)
-    if result.returncode != 0:
-        raise RuntimeError("Failed to run WireGuard setup in codespace")
-
-    # Wipe the setup script immediately after execution to avoid leaving
-    # private keys on the Codespace filesystem.
-    wipe_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
-                f'shred -u {shlex.quote(setup_path)} 2>/dev/null || rm -f {shlex.quote(setup_path)}']
-    if sudo_user and os.geteuid() == 0:
-        wipe_cmd = ['sudo', '-u', sudo_user] + wipe_cmd
-    subprocess.run(wipe_cmd, capture_output=True)
+        result = runner.run(run_cmd, input=secret_payload, text=False, timeout=180)
+        if result.returncode != 0:
+            raise RuntimeError("Failed to run WireGuard setup in codespace")
+    finally:
+        if copy_attempted:
+            # Wipe the setup script even when remote execution fails. The key
+            # material is sent over stdin, but the script is still temporary
+            # operational state and should not linger.
+            wipe_cmd = ['gh', 'codespace', 'ssh', '-c', cs_name, '--',
+                        f'shred -u {shlex.quote(setup_path)} 2>/dev/null || rm -f {shlex.quote(setup_path)}']
+            if sudo_user and os.geteuid() == 0:
+                wipe_cmd = ['sudo', '-u', sudo_user] + wipe_cmd
+            runner.run(wipe_cmd, capture_output=True, timeout=30)
 
     time.sleep(2)
 
@@ -126,8 +134,8 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     logger.info("Setting up SSH tunnel for UDP relay...")
 
     # Kill any existing local relay processes
-    subprocess.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
-    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
+    runner.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    runner.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
 
     # Verify remote socat is running
     logger.info("Verifying remote relay...")
@@ -136,7 +144,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     if sudo_user and os.geteuid() == 0:
         verify_cmd = ['sudo', '-u', sudo_user] + verify_cmd
 
-    result = subprocess.run(verify_cmd, capture_output=True, text=True)
+    result = runner.run(verify_cmd, capture_output=True, text=True)
     if 'relay running' in result.stdout:
         logger.info("Remote socat relay confirmed")
     else:
@@ -146,14 +154,14 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
                            f'UDP:127.0.0.1:{shlex.quote(str(WG_PORT))} > /tmp/socat_relay.log 2>&1 &']
         if sudo_user and os.geteuid() == 0:
             start_socat_cmd = ['sudo', '-u', sudo_user] + start_socat_cmd
-        subprocess.run(start_socat_cmd, capture_output=True)
+        runner.run(start_socat_cmd, capture_output=True)
         time.sleep(2)
 
     time.sleep(1)
 
     # Check if SSH tunnel port forward is already active
     logger.info("Starting SSH tunnel with port forward...")
-    result = subprocess.run(['ss', '-tln'], capture_output=True, text=True)
+    result = runner.run(['ss', '-tln'], capture_output=True, text=True)
     if f':{TCP_RELAY_PORT}' in result.stdout:
         logger.info(f"SSH tunnel already running on port {TCP_RELAY_PORT}")
     else:
@@ -167,7 +175,7 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
         print()
         input("Then press Enter to continue...")
 
-        result = subprocess.run(['ss', '-tln'], capture_output=True, text=True)
+        result = runner.run(['ss', '-tln'], capture_output=True, text=True)
         if f':{TCP_RELAY_PORT}' not in result.stdout:
             raise RuntimeError("SSH tunnel still not running. Please start it first.")
         logger.info("SSH tunnel detected")
@@ -185,11 +193,11 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
     # Phase 5: Bring up local WireGuard interface
     logger.info("Bringing up local WireGuard interface...")
 
-    subprocess.run(['ip', 'link', 'del', WG_INTERFACE], capture_output=True)
-    subprocess.run(['ip', 'link', 'add', WG_INTERFACE, 'type', 'wireguard'], check=True)
+    runner.run(['ip', 'link', 'del', WG_INTERFACE], capture_output=True)
+    runner.run(['ip', 'link', 'add', WG_INTERFACE, 'type', 'wireguard'], check=True)
 
     remote_pub = (wg_dir / 'remote_public.key').read_text().strip()
-    subprocess.run([
+    runner.run([
         'wg', 'set', WG_INTERFACE,
         'private-key', str(wg_dir / 'local_private.key'),
         'peer', remote_pub,
@@ -198,14 +206,14 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
         'persistent-keepalive', '25',
     ], check=True)
 
-    subprocess.run(['ip', 'addr', 'add', WG_LOCAL_IP, 'dev', WG_INTERFACE], check=True)
-    subprocess.run(['ip', 'link', 'set', WG_INTERFACE, 'up'], check=True)
+    runner.run(['ip', 'addr', 'add', WG_LOCAL_IP, 'dev', WG_INTERFACE], check=True)
+    runner.run(['ip', 'link', 'set', WG_INTERFACE, 'up'], check=True)
     time.sleep(2)
 
     # Phase 6: Test connectivity
     remote_host = WG_REMOTE_IP.split('/')[0]
     logger.info("Testing tunnel connectivity...")
-    result = subprocess.run(['ping', '-c', '1', '-W', '3', remote_host], capture_output=True)
+    result = runner.run(['ping', '-c', '1', '-W', '3', remote_host], capture_output=True, timeout=10)
     if result.returncode == 0:
         logger.info("Tunnel is UP and working!")
     else:
@@ -222,6 +230,7 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
     Equivalent to stop_tunnel() in cs-wg.sh.
     """
     logger = get_logger()
+    runner = gh.runner
 
     # Load saved codespace name if not in config
     cs_name = config.codespace_name or os.environ.get('CODESPACE_NAME', '')
@@ -239,16 +248,16 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
     logger.info("Stopping WireGuard tunnel and cleaning up...")
 
     # Restore routing if modified
-    result = subprocess.run(['ip', 'route'], capture_output=True, text=True)
+    result = runner.run(['ip', 'route'], capture_output=True, text=True)
     if f'0.0.0.0/1.*{WG_INTERFACE}' in result.stdout or \
        re.search(rf'0\.0\.0\.0/1.*{re.escape(WG_INTERFACE)}', result.stdout):
         logger.info("Restoring routing...")
-        subprocess.run(['ip', 'route', 'del', '0.0.0.0/1', 'dev', WG_INTERFACE],
-                       capture_output=True)
-        subprocess.run(['ip', 'route', 'del', '128.0.0.0/1', 'dev', WG_INTERFACE],
-                       capture_output=True)
+        runner.run(['ip', 'route', 'del', '0.0.0.0/1', 'dev', WG_INTERFACE],
+                   capture_output=True)
+        runner.run(['ip', 'route', 'del', '128.0.0.0/1', 'dev', WG_INTERFACE],
+                   capture_output=True)
         for cidr in _BYPASS_ROUTES:
-            subprocess.run(['ip', 'route', 'del', cidr], capture_output=True)
+            runner.run(['ip', 'route', 'del', cidr], capture_output=True)
 
     # Restore DNS if backed up
     wg_dir = config.config_dir / 'wireguard'
@@ -263,12 +272,12 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
             logger.warning(f"Could not restore DNS: {e}")
 
     # Remove WireGuard interface
-    result = subprocess.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
+    result = runner.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
     if result.returncode == 0:
         if os.geteuid() != 0:
             logger.warning(f"Need root to fully clean up. Run: sudo cs-wg down")
         else:
-            subprocess.run(['ip', 'link', 'del', WG_INTERFACE], capture_output=True)
+            runner.run(['ip', 'link', 'del', WG_INTERFACE], capture_output=True)
             logger.info(f"Removed {WG_INTERFACE} interface")
 
     # Stop local socat
@@ -282,9 +291,9 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
         except (OSError, ValueError):
             pass
         socat_pid_file.unlink(missing_ok=True)
-    subprocess.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
-    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
-    subprocess.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
+    runner.run(['pkill', '-f', f'socat.*UDP.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    runner.run(['pkill', '-f', f'socat.*{shlex.quote(str(WG_PORT))}'], capture_output=True)
+    runner.run(['pkill', '-f', f'socat.*{shlex.quote(str(TCP_RELAY_PORT))}'], capture_output=True)
 
     # Stop SSH tunnel
     logger.info("Stopping SSH tunnel...")
@@ -297,9 +306,9 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
         except (OSError, ValueError):
             pass
         ssh_pid_file.unlink(missing_ok=True)
-    subprocess.run(['pkill', '-f', 'gh.*codespace.*ssh.*-L'], capture_output=True)
-    subprocess.run(['pkill', '-f', f'ssh.*{shlex.quote(str(TCP_RELAY_PORT))}:127.0.0.1'], capture_output=True)
-    subprocess.run(['fuser', '-k', f'{shlex.quote(str(TCP_RELAY_PORT))}/tcp'], capture_output=True)
+    runner.run(['pkill', '-f', 'gh.*codespace.*ssh.*-L'], capture_output=True)
+    runner.run(['pkill', '-f', f'ssh.*{shlex.quote(str(TCP_RELAY_PORT))}:127.0.0.1'], capture_output=True)
+    runner.run(['fuser', '-k', f'{shlex.quote(str(TCP_RELAY_PORT))}/tcp'], capture_output=True)
 
     # Stop remote WireGuard if codespace accessible
     if cs_name:
@@ -309,7 +318,7 @@ def stop_tunnel(config: Config, gh: GitHubManager) -> None:
                        f'pkill -f socat.*TCP-LISTEN.*{shlex.quote(str(TCP_RELAY_PORT))} 2>/dev/null || true']
         if sudo_user and os.geteuid() == 0:
             cleanup_cmd = ['sudo', '-u', sudo_user] + cleanup_cmd
-        subprocess.run(cleanup_cmd, capture_output=True)
+        runner.run(cleanup_cmd, capture_output=True, timeout=60)
 
     # Clean up state files
     cs_file = config.config_dir / 'current_codespace'
@@ -330,6 +339,7 @@ def show_status(config: Config, gh: GitHubManager) -> None:
     Equivalent to show_status() in cs-wg.sh.
     """
     # Load saved codespace name
+    runner = gh.runner
     cs_name = config.codespace_name or os.environ.get('CODESPACE_NAME', '')
     if not cs_name:
         cs_file = config.config_dir / 'current_codespace'
@@ -343,10 +353,10 @@ def show_status(config: Config, gh: GitHubManager) -> None:
     print(f"\n=== cs-wg Status ===\n")
 
     # Check interface
-    result = subprocess.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
+    result = runner.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
     if result.returncode == 0:
         print(f"Interface:       {WG_INTERFACE} UP")
-        result2 = subprocess.run(['wg', 'show', WG_INTERFACE], capture_output=True, text=True)
+        result2 = runner.run(['wg', 'show', WG_INTERFACE], capture_output=True, text=True)
         if result2.returncode == 0:
             print()
             print(result2.stdout)
@@ -361,18 +371,18 @@ def show_status(config: Config, gh: GitHubManager) -> None:
     print(f"Codespace:       {cs_name or '<not set>'}")
 
     # Test connectivity if interface is up
-    result = subprocess.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
+    result = runner.run(['ip', 'link', 'show', WG_INTERFACE], capture_output=True)
     if result.returncode == 0:
         remote_host = WG_REMOTE_IP.split('/')[0]
         print()
-        result = subprocess.run(['ping', '-c', '1', '-W', '2', remote_host], capture_output=True)
+        result = runner.run(['ping', '-c', '1', '-W', '2', remote_host], capture_output=True, timeout=10)
         if result.returncode == 0:
             print("Tunnel:          CONNECTED")
 
             # Test internet through tunnel
             remote_ip = None
             for url in ['https://api.ipify.org', 'https://ifconfig.me', 'https://icanhazip.com']:
-                result = subprocess.run(
+                result = runner.run(
                     ['curl', '-4', '-s', '--interface', WG_INTERFACE,
                      '--connect-timeout', '5', url],
                     capture_output=True, text=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0",
     "colorama>=0.4.6",
+    "portalocker>=2.8",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ pyyaml>=6.0
 # Cross-platform colored terminal output
 colorama>=0.4.6
 
+# Cross-platform advisory file locks
+portalocker>=2.8
+
 # Optional but recommended dependencies
 # Uncomment if needed:
 # requests>=2.31.0     # HTTP requests (may be needed for some features)

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -152,16 +152,18 @@ def test_wireguard_setup_script_renders():
     """WireGuard remote setup script template renders correctly."""
     from csproxy.wireguard import _REMOTE_SETUP_SCRIPT
     rendered = _REMOTE_SETUP_SCRIPT.format(
-        remote_private_key='TEST_KEY=',
         wg_remote_ip='10.99.99.1/24',
         wg_port=51820,
         wg_network='10.99.99.0/24',
-        local_public_key='TEST_PUB=',
         local_ip_host='10.99.99.2',
         remote_ip_host='10.99.99.1',
     )
     assert '#!/usr/bin/env bash' in rendered
-    assert 'TEST_KEY=' in rendered
+    assert 'TEST_KEY=' not in rendered
+    assert 'PrivateKey = ${REMOTE_PRIVATE_KEY}' in rendered
+    assert 'PublicKey = ${LOCAL_PUBLIC_KEY}' in rendered
+    assert '<< WGCONF' in rendered
+    assert "<< 'WGCONF'" not in rendered
 
 
 def test_health_check_uses_socks5_hostname():

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -368,25 +368,23 @@ def check_wireguard_module():
         assert WG_NETWORK == '10.99.99.0/24'
         print(f"  [+] WG defaults: interface={WG_INTERFACE}, port={WG_PORT}")
 
-        # Verify remote setup script is valid Bash (check for shebang and key markers)
+        # Verify remote setup script is valid Bash and reads key material at runtime.
         assert '#!/usr/bin/env bash' in _REMOTE_SETUP_SCRIPT
         assert 'wg-quick up wg0' in _REMOTE_SETUP_SCRIPT
-        assert '{remote_private_key}' in _REMOTE_SETUP_SCRIPT
-        assert '{local_public_key}' in _REMOTE_SETUP_SCRIPT
+        assert 'read -r REMOTE_PRIVATE_KEY' in _REMOTE_SETUP_SCRIPT
+        assert 'read -r LOCAL_PUBLIC_KEY' in _REMOTE_SETUP_SCRIPT
         print("  [+] Remote setup script template is valid")
 
         # Verify script renders without error when format() is called with test values
         rendered = _REMOTE_SETUP_SCRIPT.format(
-            remote_private_key='TEST_PRIV_KEY=',
             wg_remote_ip='10.99.99.1/24',
             wg_port=51820,
             wg_network='10.99.99.0/24',
-            local_public_key='TEST_PUB_KEY=',
             local_ip_host='10.99.99.2',
             remote_ip_host='10.99.99.1',
         )
-        assert 'TEST_PRIV_KEY=' in rendered
-        assert 'TEST_PUB_KEY=' in rendered
+        assert 'TEST_PRIV_KEY=' not in rendered
+        assert 'TEST_PUB_KEY=' not in rendered
         assert '#!/usr/bin/env bash' in rendered
         print("  [+] Remote setup script renders correctly")
 

--- a/tests/test_phase2_features.py
+++ b/tests/test_phase2_features.py
@@ -380,6 +380,35 @@ def test_state_update_tunnel(tmp_path):
     assert t["status"] == "healthy"
 
 
+def test_state_add_tunnel_concurrent_writes_do_not_clobber(tmp_path):
+    import threading
+    from csproxy.state import State
+
+    state = State(tmp_path)
+
+    def add(idx):
+        state.add_tunnel(
+            id=f"ssh-{1080 + idx}",
+            kind="ssh",
+            codespace_name=f"test-cs-{idx}",
+            port=1080 + idx,
+            pid=12345 + idx,
+            status="healthy",
+            created=0,
+            failures=0,
+            last_failure=0,
+        )
+
+    threads = [threading.Thread(target=add, args=(idx,)) for idx in range(12)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    ports = sorted(t["port"] for t in state.get_tunnels(kind="ssh"))
+    assert ports == list(range(1080, 1092))
+
+
 def test_state_reconcile_marks_dead_pid_as_crashed(tmp_path):
     from csproxy.state import State
     state = State(tmp_path)

--- a/tests/test_phase2_infrastructure.py
+++ b/tests/test_phase2_infrastructure.py
@@ -35,6 +35,27 @@ def test_command_runner_merges_env(monkeypatch):
     assert env["CALL"] == "3"
 
 
+def test_command_runner_allows_explicit_no_timeout():
+    from csproxy.runner import CommandRunner
+
+    runner = CommandRunner()
+
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 0)) as mock_run:
+        runner.run(["tail", "-f", "log"], timeout=None, capture_output=False)
+
+    assert mock_run.call_args.kwargs["timeout"] is None
+
+
+def test_command_runner_redacts_sensitive_command_and_env():
+    from csproxy.runner import CommandRunner
+
+    runner = CommandRunner(redacted_values=("github_pat_secret",))
+
+    assert "github_pat_secret" not in runner._display_cmd(["gh", "api", "github_pat_secret"])
+    assert "TOKEN=***" in runner._display_env({"TOKEN": "github_pat_secret"})
+    assert "github_pat_secret" not in runner._display_env({"HEADER": "bearer github_pat_secret"})
+
+
 def test_github_account_loads_from_config(monkeypatch, tmp_path):
     from csproxy.accounts import GitHubAccount
     from csproxy.utils.config import Config
@@ -79,3 +100,15 @@ def test_github_manager_uses_account_token(monkeypatch, tmp_path):
         assert gh.check_auth() is True
 
     assert mock_run.call_args.kwargs["env"]["GH_TOKEN"] == "secret"
+
+
+def test_github_manager_registers_loaded_token_for_redaction(monkeypatch, tmp_path):
+    from csproxy.github import GitHubManager
+    from csproxy.runner import CommandRunner
+
+    runner = CommandRunner()
+    monkeypatch.setenv("GH_TOKEN", "github_pat_loadedsecret")
+    gh = GitHubManager(config_dir=tmp_path, runner=runner)
+
+    assert gh.load_token() == "github_pat_loadedsecret"
+    assert "github_pat_loadedsecret" in runner.redacted_values

--- a/tests/test_phase3_chains.py
+++ b/tests/test_phase3_chains.py
@@ -21,6 +21,8 @@ def test_chain_create_persists_two_hops(tmp_path):
     assert [h["location"] for h in chain["hops"]] == ["WestEurope", "EastUs"]
     assert chain["hop1_port"] == 18080
     assert chain["hop2_port"] == 18081
+    assert isinstance(chain["relay_secret"], str)
+    assert len(chain["relay_secret"]) >= 32
 
 
 def test_chain_create_requires_exactly_two_hops(tmp_path):
@@ -72,3 +74,202 @@ def test_wait_local_forward_fails_if_process_exits():
 
     with pytest.raises(RuntimeError, match="exited before becoming ready"):
         _wait_local_forward(19080, DeadProcess(), "chain SOCKS", timeout=1)
+
+
+def test_chain_scripts_require_and_send_relay_secret(tmp_path):
+    import py_compile
+    from csproxy.chains import EXIT_RELAY_SCRIPT, SOCKS_RELAY_SCRIPT
+
+    exit_script = EXIT_RELAY_SCRIPT
+    socks_script = SOCKS_RELAY_SCRIPT
+
+    assert "CS_PROXY_RELAY_SECRET_FILE" in exit_script
+    assert "X-CSProxy-Chain-Secret" in exit_script
+    assert "send_response(403)" in exit_script
+    assert "secret123" not in exit_script
+    assert "CS_PROXY_RELAY_SECRET_FILE" in socks_script
+    assert "X-CSProxy-Chain-Secret" in socks_script
+    assert "CS_PROXY_EXIT_HOST" in socks_script
+    assert "secret123" not in socks_script
+
+    exit_path = tmp_path / "csproxy-test-exit.py"
+    socks_path = tmp_path / "csproxy-test-socks.py"
+    exit_path.write_text(exit_script)
+    socks_path.write_text(socks_script)
+    py_compile.compile(exit_path, doraise=True)
+    py_compile.compile(socks_path, doraise=True)
+
+
+def test_chain_secret_backfills_older_configs():
+    from csproxy.chains import _chain_secret
+
+    chain = {"name": "legacy"}
+
+    secret = _chain_secret(chain)
+
+    assert chain["relay_secret"] == secret
+    assert len(secret) >= 32
+
+
+def test_chain_start_rolls_back_on_forward_timeout(tmp_path):
+    import pytest
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, call, patch
+
+    from csproxy.chains import _cmd_chain_start
+    from csproxy.utils.config import Config
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+            self.terminated = False
+            self.killed = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            self.killed = True
+
+    config = Config(config_dir=tmp_path)
+    config.set(
+        "chains",
+        {
+            "eu-us": {
+                "name": "eu-us",
+                "hops": [
+                    {"location": "WestEurope", "codespace_name": "hop-one"},
+                    {"location": "EastUs", "codespace_name": "hop-two"},
+                ],
+                "hop1_port": 18080,
+                "hop2_port": 18081,
+                "relay_secret": "secret",
+            }
+        },
+    )
+    parsed = SimpleNamespace(name="eu-us", port=19080)
+    gh = MagicMock()
+    exit_forward = FakeProcess(101)
+    socks_forward = FakeProcess(102)
+
+    with patch("csproxy.chains._ensure_chain_hops", return_value=config.get("chains")["eu-us"]["hops"]), \
+         patch("csproxy.chains._upload"), \
+         patch("csproxy.chains._upload_secret_file"), \
+         patch("csproxy.chains._start_remote_script"), \
+         patch("csproxy.chains._cleanup_remote_script") as cleanup_script, \
+         patch("csproxy.chains._cleanup_remote_file") as cleanup_file, \
+         patch("csproxy.chains._set_port_private") as set_port_private, \
+         patch("csproxy.chains.subprocess.Popen", side_effect=[exit_forward, socks_forward]), \
+         patch("csproxy.chains._wait_local_forward", side_effect=[None, RuntimeError("Timed out waiting")]):
+        with pytest.raises(RuntimeError, match="Timed out waiting"):
+            _cmd_chain_start(parsed, config, gh)
+
+    assert exit_forward.terminated is True
+    assert socks_forward.terminated is True
+    cleanup_script.assert_has_calls(
+        [
+            call(gh, "hop-one", "/tmp/csproxy_chain_socks_18080.py"),
+            call(gh, "hop-two", "/tmp/csproxy_chain_exit_18081.py"),
+        ],
+        any_order=False,
+    )
+    cleanup_file.assert_has_calls(
+        [
+            call(gh, "hop-one", "/tmp/csproxy_chain_socks_18080.secret"),
+            call(gh, "hop-two", "/tmp/csproxy_chain_exit_18081.secret"),
+        ],
+        any_order=False,
+    )
+    set_port_private.assert_has_calls(
+        [
+            call(gh, "hop-one", 18080),
+            call(gh, "hop-two", 18081),
+        ],
+        any_order=False,
+    )
+
+
+def test_start_remote_script_places_env_before_nohup():
+    from unittest.mock import MagicMock, patch
+
+    from csproxy.chains import _start_remote_script
+
+    gh = MagicMock()
+
+    with patch("csproxy.chains._ssh", return_value=MagicMock(returncode=0)) as ssh, \
+         patch("csproxy.chains.time.sleep"):
+        _start_remote_script(
+            gh,
+            "fake-cs",
+            "/tmp/relay.py",
+            "relay",
+            env={"CS_PROXY_RELAY_PORT": "18080", "CS_PROXY_EXIT_HOST": "host.test"},
+        )
+
+    cmd = ssh.call_args.args[2]
+    assert cmd.startswith("CS_PROXY_RELAY_PORT=18080 CS_PROXY_EXIT_HOST=host.test nohup python3")
+    assert "nohup CS_PROXY_RELAY_PORT" not in cmd
+
+
+def test_cleanup_remote_script_uses_safe_process_pattern():
+    from unittest.mock import MagicMock, patch
+
+    from csproxy.chains import _cleanup_remote_script
+
+    gh = MagicMock()
+
+    with patch("csproxy.chains._ssh") as ssh:
+        _cleanup_remote_script(gh, "fake-cs", "/tmp/csproxy_chain_exit_18081.py")
+
+    cmd = ssh.call_args.args[2]
+    assert "pgrep -f '[p]ython3 .*[/]tmp/csproxy_chain_exit_18081.py'" in cmd
+    assert "pkill -f" not in cmd
+    assert "rm -f /tmp/csproxy_chain_exit_18081.py /tmp/csproxy_chain_exit_18081.py.log" in cmd
+
+
+def test_chain_stop_sets_ports_private_and_removes_artifacts(tmp_path):
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock, call, patch
+
+    from csproxy.chains import _cmd_chain_stop
+    from csproxy.state import State
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    State(tmp_path).add_tunnel(
+        id="chain-livews",
+        kind="chain",
+        name="livews",
+        status="healthy",
+        local_port=19083,
+        pid=0,
+        exit_forward_pid=0,
+        hop1_port=18080,
+        hop2_port=18081,
+        hops=[
+            {"location": "EastUs", "codespace_name": "same-cs"},
+            {"location": "EastUs", "codespace_name": "same-cs"},
+        ],
+    )
+
+    gh = MagicMock()
+
+    with patch("csproxy.chains._ssh") as ssh, \
+         patch("csproxy.chains._set_port_private") as set_port_private:
+        result = _cmd_chain_stop(SimpleNamespace(name="livews"), config, gh)
+
+    assert result == 0
+    assert "rm -f /tmp/csproxy_chain_*" in ssh.call_args_list[0].args[2]
+    set_port_private.assert_has_calls(
+        [
+            call(gh, "same-cs", 18080),
+            call(gh, "same-cs", 18081),
+        ],
+        any_order=False,
+    )

--- a/tests/test_phase3_hardening.py
+++ b/tests/test_phase3_hardening.py
@@ -86,6 +86,33 @@ def test_health_check_records_failure_on_bad_check(tmp_path):
     assert t["failures"] == 1
 
 
+def test_health_check_uses_configured_url(tmp_path):
+    from csproxy.state import State
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    config.set("health_check_url", "https://example.test/health")
+    State(tmp_path).add_tunnel(
+        id="ssh-1080",
+        kind="ssh",
+        codespace_name="test-cs",
+        port=1080,
+        pid=12345,
+        status="healthy",
+        created=0,
+        failures=0,
+        last_failure=0,
+    )
+    tunnel = SSHTunnel(config, "test-cs", port=1080)
+    mock_result = MagicMock(returncode=0)
+
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        tunnel.health_check()
+
+    assert "https://example.test/health" in mock_run.call_args.args[0]
+
+
 def test_health_check_trips_circuit_breaker(tmp_path):
     from csproxy.state import State
     from csproxy.tunnel import SSHTunnel
@@ -140,6 +167,16 @@ def test_config_load_warns_on_deprecated_key(tmp_path):
     warning_calls = [c for c in mock_logger.warning.call_args_list if "chain" in str(c)]
     assert len(warning_calls) >= 1
     assert "Deprecated config key 'chain'" in str(warning_calls[0])
+
+
+def test_config_rejects_non_http_health_url(tmp_path):
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+
+    config.set("health_check_url", "file:///tmp/nope")
+
+    assert config.health_check_url == "https://ifconfig.me"
 
 
 # =============================================================================
@@ -232,3 +269,128 @@ def test_cli_parses_dry_run_flag():
         with patch("csproxy.proxy.show_help"):
             result = main_proxy(["--dry-run", "help"])
     assert result == 0
+
+
+def test_set_github_token_accepts_fine_grained_pat(tmp_path):
+    from csproxy.github import GitHubManager
+    from csproxy.proxy import set_github_token
+    from csproxy.utils.config import Config
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+    token = "github_pat_" + "a" * 40
+
+    with patch("subprocess.run", return_value=MagicMock(returncode=0)):
+        set_github_token(token, config, gh)
+
+    assert (tmp_path / "gh_token").read_text() == token
+
+
+def test_worker_trims_oversized_log(tmp_path):
+    from csproxy._worker import _trim_log_file
+
+    log_file = tmp_path / "proxy.log"
+    log_file.write_bytes(b"a" * 100 + b"recent")
+
+    _trim_log_file(log_file, 20)
+
+    data = log_file.read_bytes()
+    assert data.startswith(b"[csproxy] log truncated")
+    assert data.endswith(b"recent")
+
+
+def test_worker_status_file_records_status(tmp_path):
+    import json
+    from csproxy._worker import _write_status
+
+    status_file = tmp_path / "worker.status.json"
+
+    _write_status(status_file, "running", attempt=2)
+
+    data = json.loads(status_file.read_text())
+    assert data["status"] == "running"
+    assert data["attempt"] == 2
+    assert data["pid"] > 0
+
+
+def test_tunnel_worker_ready_timeout_cleans_spec(tmp_path):
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+    from csproxy.utils.errors import SSHTunnelError
+
+    config = Config(config_dir=tmp_path)
+    tunnel = SSHTunnel(config, "test-cs", port=1080)
+    tunnel.spec_file.parent.mkdir(parents=True, exist_ok=True)
+    tunnel.spec_file.write_text("{}")
+
+    class RunningProcess:
+        returncode = None
+
+        def poll(self):
+            return None
+
+    with pytest.raises(SSHTunnelError, match="did not signal readiness"):
+        tunnel._wait_for_worker_ready(RunningProcess(), tunnel.spec_file.with_suffix(".stderr"), timeout=0.01)
+
+    assert not tunnel.spec_file.exists()
+
+
+def test_tunnel_stop_kills_port_holders_and_stop_file(tmp_path):
+    from csproxy.tunnel import SSHTunnel
+    from csproxy.utils.config import Config
+
+    tunnel = SSHTunnel(Config(config_dir=tmp_path), "test-cs", port=1080)
+    tunnel.stop_file.touch()
+
+    with patch.object(tunnel, "_kill_port_holders") as kill_port_holders:
+        tunnel.stop()
+
+    kill_port_holders.assert_called_once()
+    assert not tunnel.stop_file.exists()
+
+
+def test_wireguard_setup_script_is_wiped_on_remote_run_failure(tmp_path):
+    from csproxy.github import GitHubManager
+    from csproxy.utils.config import Config
+    from csproxy import wireguard
+
+    config = Config(config_dir=tmp_path)
+    gh = GitHubManager(config_dir=tmp_path)
+
+    run_results = [
+        MagicMock(returncode=0, stdout="", stderr=b""),  # upload setup script
+        MagicMock(returncode=1, stdout="", stderr=b"boom"),  # run setup script
+        MagicMock(returncode=0, stdout="", stderr=b""),  # wipe setup script
+    ]
+
+    with patch("csproxy.wireguard._check_root"), \
+         patch("csproxy.wireguard._ensure_dirs"), \
+         patch("csproxy.wireguard.generate_keys"), \
+         patch("csproxy.wireguard._select_codespace", return_value="codespace-a"), \
+         patch("csproxy.wireguard._ensure_codespace_running"), \
+         patch("csproxy.wireguard._run_gh", return_value=MagicMock(stdout="SSH OK")), \
+         patch("csproxy.wireguard.generate_local_config"), \
+         patch("csproxy.wireguard._build_remote_setup_script", return_value="#!/bin/sh\nsecret"), \
+         patch("csproxy.wireguard._remote_setup_secret_payload", return_value=b"secret\npub\n"), \
+         patch("subprocess.run", side_effect=run_results) as mock_run:
+        with pytest.raises(RuntimeError, match="Failed to run WireGuard setup"):
+            wireguard.start_tunnel(config, gh)
+
+    wipe_cmd = mock_run.call_args_list[2].args[0]
+    assert "shred -u /tmp/setup_wg.sh" in wipe_cmd[-1]
+
+
+def test_wireguard_remote_setup_script_does_not_embed_keys(tmp_path):
+    from csproxy.wg_setup import build_remote_setup_script, remote_setup_secret_payload
+
+    wg_dir = tmp_path / "wireguard"
+    wg_dir.mkdir()
+    (wg_dir / "remote_private.key").write_text("priv-value-123")
+    (wg_dir / "local_public.key").write_text("pub-value-456")
+
+    script = build_remote_setup_script(wg_dir)
+    payload = remote_setup_secret_payload(wg_dir)
+
+    assert "priv-value-123" not in script
+    assert "pub-value-456" not in script
+    assert b"priv-value-123\npub-value-456\n" == payload


### PR DESCRIPTION
## Summary
- Extract chain relay scripts into versioned Python modules and add per-chain WebSocket authentication.
- Harden tunnel lifecycle handling with worker readiness/status files, bounded logs, reliable stop cleanup, and state locking.
- Move normal subprocess execution through CommandRunner with token/env redaction and no-timeout support for streaming commands.
- Send WireGuard remote setup key material over stdin instead of embedding keys in uploaded scripts.
- Add rollback cleanup for chain startup failures, remote relay artifact cleanup, and private reset for chain ports on stop/rollback.

## Sanitized Test Results
- `python3 -m pytest -q` -> `123 passed`.
- `python3 -m compileall -q csproxy` -> passed.
- `git diff --check` -> passed.
- Installed-package smoke in a throwaway venv: `cs-proxy`, `cs-tools`, `cs-serve`, and `cs-wg` entrypoints exercised successfully.
- Live disposable Codespaces smoke using a non-production test account: SSH connectivity, `cs-proxy list`, SOCKS start/status/curl, worker status file, and stop cleanup passed.
- Live chain smoke using the hardened WebSocket relay path: chained SOCKS curl passed; unauthenticated HTTP/1.1 WebSocket upgrade returned `403 Forbidden`; stop removed local listeners and remote relay artifacts; chain ports were reset to private.
- Disposable live test Codespace was deleted after validation.

No Codespace names, token values, or secret material are included in this PR body.
