### PR TITLE
Route interactive prompts to stderr; ignore portalocker in mypy

### DIFF
--- a/csproxy/codespace.py
+++ b/csproxy/codespace.py
@@ -9,7 +9,7 @@ Extracted from proxy.py for modularity.
 import time
 
 from .github import GitHubManager
-from .utils import Config, get_logger
+from .utils import Config, eprint, get_logger, prompt
 
 
 class CodespaceSelector:
@@ -56,15 +56,15 @@ class CodespaceSelector:
 
     def _create_interactively(self) -> str:
         """Prompt user for repo and create a new Codespace."""
-        print(f"\nEnter repository (owner/repo, or press Enter for {self.BLANK_REPO}):")
-        repo = input("> ").strip() or self.BLANK_REPO
+        eprint(f"\nEnter repository (owner/repo, or press Enter for {self.BLANK_REPO}):")
+        repo = prompt("> ").strip() or self.BLANK_REPO
 
         location = self.config.location
         if not location:
-            print("\nSelect region (or press Enter for no preference):")
+            eprint("\nSelect region (or press Enter for no preference):")
             for i, (value, label) in enumerate(self.LOCATIONS, 1):
-                print(f"  {i}) {value:<16} ({label})")
-            choice = input("> ").strip()
+                eprint(f"  {i}) {value:<16} ({label})")
+            choice = prompt("> ").strip()
             if choice.isdigit():
                 idx = int(choice) - 1
                 if 0 <= idx < len(self.LOCATIONS):
@@ -165,15 +165,15 @@ class CodespaceSelector:
     def _prompt_selection(self, codespaces: list) -> str:
         """Prompt user to select from multiple Codespaces."""
         self.logger.info("Available Codespaces:")
-        print()
+        eprint()
         for i, cs in enumerate(codespaces, 1):
             name = cs.get("name", "unknown")
             state = cs.get("state", "unknown")
             repo = cs.get("repository", "unknown")
-            print(f"  {i}) {name:<40} {state:<15} {repo}")
-        print()
+            eprint(f"  {i}) {name:<40} {state:<15} {repo}")
+        eprint()
 
-        selection = input("Enter number, name, or press Enter for most recent: ").strip()
+        selection = prompt("Enter number, name, or press Enter for most recent: ").strip()
 
         if not selection:
             sorted_cs = sorted(codespaces, key=lambda x: x.get("createdAt", ""), reverse=True)

--- a/csproxy/proxy.py
+++ b/csproxy/proxy.py
@@ -19,7 +19,9 @@ from .utils import (
     Config,
     GitHubAuthError,
     check_dependencies,
+    eprint,
     get_logger,
+    prompt,
 )
 
 # Re-export classes from extracted modules for backward compatibility
@@ -91,7 +93,7 @@ def generate_ssh_key(config: Config) -> None:
 
     if key_file.exists():
         logger.warning(f"SSH key already exists at {key_file}")
-        answer = input("Regenerate? [y/N] ").strip().lower()
+        answer = prompt("Regenerate? [y/N] ").strip().lower()
         if answer != "y":
             return
 
@@ -139,9 +141,9 @@ def set_github_token(token: str, config: Config, gh: GitHubManager) -> None:
     logger = get_logger()
 
     if not token:
-        print("Enter your GitHub Personal Access Token:")
-        print("(Create one at https://github.com/settings/tokens/new with 'codespace' scope)")
-        token = input("> ").strip()
+        eprint("Enter your GitHub Personal Access Token:")
+        eprint("(Create one at https://github.com/settings/tokens/new with 'codespace' scope)")
+        token = prompt("> ").strip()
 
     if not token:
         raise ValueError("No token provided")
@@ -150,7 +152,7 @@ def set_github_token(token: str, config: Config, gh: GitHubManager) -> None:
         token.startswith("ghp_") or token.startswith("ghs_") or token.startswith("github_pat_")
     ):
         logger.warning("Token doesn't match expected format (ghp_*, ghs_*, or github_pat_*)")
-        answer = input("Continue anyway? [y/N] ").strip().lower()
+        answer = prompt("Continue anyway? [y/N] ").strip().lower()
         if answer != "y":
             raise ValueError("Aborted")
 
@@ -176,12 +178,12 @@ def setup_split_tunnel(config: Config) -> None:
     logger = get_logger()
     target_file = config.config_dir / "targets.txt"
 
-    print("Split tunneling routes specific targets through the proxy.")
-    print("Enter target domains/IPs (one per line, empty line to finish):\n")
+    eprint("Split tunneling routes specific targets through the proxy.")
+    eprint("Enter target domains/IPs (one per line, empty line to finish):\n")
 
     targets = []
     while True:
-        target = input("> ").strip()
+        target = prompt("> ").strip()
         if not target:
             break
         targets.append(target)
@@ -499,12 +501,12 @@ def _pick_codespace(args, config: Config, gh: GitHubManager) -> str:
         return arg  # treat as explicit name
 
     if len(names) > 1:
-        print("\nSelect Codespace:")
+        eprint("\nSelect Codespace:")
         for i, name in enumerate(names, 1):
             idx = names.index(name)
             role = f" [:{config.socks_port + idx}]"
-            print(f"  {i}) {name}{role}")
-        choice = input("> ").strip()
+            eprint(f"  {i}) {name}{role}")
+        choice = prompt("> ").strip()
         if choice.isdigit():
             idx = int(choice) - 1
             if 0 <= idx < len(names):
@@ -629,12 +631,12 @@ def cmd_down(args, config: Config, gh: GitHubManager) -> int:
 
     # Step 3: confirm deletion
     if len(all_names) > 1:
-        print(f"\nThis will PERMANENTLY delete {len(all_names)} managed codespaces:")
+        eprint(f"\nThis will PERMANENTLY delete {len(all_names)} managed codespaces:")
         for name in all_names:
-            print(f"  - {name}")
+            eprint(f"  - {name}")
     else:
-        print(f"\nThis will PERMANENTLY delete: {all_names[0]}")
-    confirm = input("Are you sure? [y/N] ").strip().lower()
+        eprint(f"\nThis will PERMANENTLY delete: {all_names[0]}")
+    confirm = prompt("Are you sure? [y/N] ").strip().lower()
     if confirm != "y":
         logger.info("Cancelled — codespaces were stopped but not deleted.")
         return 0
@@ -668,17 +670,17 @@ def cmd_delete(args, config: Config, gh: GitHubManager) -> int:
     names = [cs["name"] for cs in codespaces]
 
     if len(names) > 1:
-        print(f"\nYou have {len(names)} codespaces:")
+        eprint(f"\nYou have {len(names)} codespaces:")
         for i, name in enumerate(names, 1):
-            print(f"  {i}) {name}")
-        print()
-        print("Options:")
-        print("  a) Delete ALL")
+            eprint(f"  {i}) {name}")
+        eprint()
+        eprint("Options:")
+        eprint("  a) Delete ALL")
         for i, name in enumerate(names, 1):
-            print(f"  {i}) Delete only {name}")
-        print("  n) Cancel")
-        print()
-        choice = input("Choice: ").strip().lower()
+            eprint(f"  {i}) Delete only {name}")
+        eprint("  n) Cancel")
+        eprint()
+        choice = prompt("Choice: ").strip().lower()
 
         if choice == "a":
             to_delete = names
@@ -689,8 +691,8 @@ def cmd_delete(args, config: Config, gh: GitHubManager) -> int:
             return 0
     else:
         to_delete = names
-        print(f"\nThis will PERMANENTLY delete: {to_delete[0]}")
-        confirm = input("Are you sure? [y/N] ").strip().lower()
+        eprint(f"\nThis will PERMANENTLY delete: {to_delete[0]}")
+        confirm = prompt("Are you sure? [y/N] ").strip().lower()
         if confirm != "y":
             logger.info("Cancelled")
             return 0

--- a/csproxy/utils/__init__.py
+++ b/csproxy/utils/__init__.py
@@ -24,9 +24,13 @@ from .errors import (
     SSHTunnelError,
     WireGuardError,
 )
+from .interaction import eprint, prompt
 from .logging import get_logger, log_debug, log_error, log_info, log_warn, setup_logger
 
 __all__ = [
+    # Interaction
+    "eprint",
+    "prompt",
     # Logging
     "setup_logger",
     "get_logger",

--- a/csproxy/utils/interaction.py
+++ b/csproxy/utils/interaction.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Helpers for interactive terminal prompts.
+
+Prompts and their surrounding menus are written to stderr rather than stdout so
+they stay visible when stdout is piped or captured -- e.g. ``cs-proxy delete |
+tail``. A prompt written to a block-buffered stdout pipe never reaches the
+terminal, so the command appears to hang with no visible question while it
+blocks on ``input()``. Routing prompts to stderr also follows the usual Unix
+split: machine-readable data on stdout, human interaction on stderr.
+"""
+
+import sys
+from typing import Any
+
+
+def eprint(*args: Any, **kwargs: Any) -> None:
+    """``print`` to stderr, so interactive output survives stdout redirection."""
+    kwargs.setdefault("file", sys.stderr)
+    print(*args, **kwargs)
+
+
+def prompt(message: str = "") -> str:
+    """Write ``message`` to stderr and read one line from stdin.
+
+    Mirrors ``input(message)`` but routes the prompt to stderr so it is not
+    swallowed by a piped or block-buffered stdout. Returns the line as typed
+    (callers strip as needed).
+    """
+    if message:
+        sys.stderr.write(message)
+        sys.stderr.flush()
+    return input()

--- a/csproxy/wg_routes.py
+++ b/csproxy/wg_routes.py
@@ -12,7 +12,7 @@ import subprocess
 from pathlib import Path
 
 from .runner import CommandRunner
-from .utils import Config, get_logger
+from .utils import Config, get_logger, prompt
 from .wg_constants import WG_INTERFACE
 
 # GitHub/Azure IP ranges to bypass when routing all traffic through tunnel.
@@ -104,7 +104,7 @@ def route_all(config: Config, interface: str = WG_INTERFACE) -> None:
 
     logger.warning("This will route ALL traffic through the Codespace!")
     logger.warning("The SSH tunnel and local network will be preserved.")
-    confirm = input("Continue? [y/N] ").strip().lower()
+    confirm = prompt("Continue? [y/N] ").strip().lower()
     if confirm not in ("y", "yes"):
         return
 

--- a/csproxy/wg_setup.py
+++ b/csproxy/wg_setup.py
@@ -16,7 +16,7 @@ from typing import Optional
 from .github import GitHubManager
 from .runner import CommandRunner
 from .templates import WG_REMOTE_SETUP_SCRIPT as _REMOTE_SETUP_SCRIPT
-from .utils import Config, get_logger
+from .utils import Config, eprint, get_logger, prompt
 from .wg_constants import (
     WG_INTERFACE as _WG_INTERFACE,
     WG_PORT as _WG_PORT,
@@ -151,15 +151,15 @@ def select_codespace(gh: GitHubManager, config: Config, sudo_user: Optional[str]
         logger.info(f"Auto-selected: {cs_name}")
     else:
         logger.info("Available Codespaces:")
-        print()
+        eprint()
         for i, cs in enumerate(cs_list, 1):
-            print(
+            eprint(
                 f"  {i:2}) {cs['name']:<40} "
                 f"{cs.get('state', '?'):<12} {cs.get('repository', '')}"
             )
-        print()
+        eprint()
 
-        selection = input("Enter number or name (Enter for most recent): ").strip()
+        selection = prompt("Enter number or name (Enter for most recent): ").strip()
 
         if not selection:
             cs_name = cs_list[0]["name"]

--- a/csproxy/wireguard.py
+++ b/csproxy/wireguard.py
@@ -14,7 +14,7 @@ import subprocess
 import time
 
 from .github import GitHubManager
-from .utils import Config, get_logger
+from .utils import Config, eprint, get_logger, prompt
 
 # Re-export from extracted modules for backward compatibility
 from .templates import WG_REMOTE_SETUP_SCRIPT as _REMOTE_SETUP_SCRIPT  # noqa: F401
@@ -211,16 +211,16 @@ def start_tunnel(config: Config, gh: GitHubManager) -> None:
         logger.info(f"SSH tunnel already running on port {TCP_RELAY_PORT}")
     else:
         logger.warning(f"SSH tunnel not running on port {TCP_RELAY_PORT}")
-        print()
-        print("The SSH tunnel must be started as your regular user (not root).")
-        print("Please run this in another terminal:")
-        print()
-        print(
+        eprint()
+        eprint("The SSH tunnel must be started as your regular user (not root).")
+        eprint("Please run this in another terminal:")
+        eprint()
+        eprint(
             f"  gh codespace ssh -c {shlex.quote(cs_name)} -- "
             f"-T -L 127.0.0.1:{TCP_RELAY_PORT}:127.0.0.1:{TCP_RELAY_PORT} -N &"
         )
-        print()
-        input("Then press Enter to continue...")
+        eprint()
+        prompt("Then press Enter to continue...")
 
         result = runner.run(["ss", "-tln"], capture_output=True, text=True)
         if f":{TCP_RELAY_PORT}" not in result.stdout:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,14 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false
 
-# Third-party packages without type information. textual is only present with
-# the optional [tui] extra (not installed in the lint job); yaml and colorama
-# ship no stubs in this environment.
+# Third-party packages without usable type info in every environment that runs
+# mypy. textual is only present with the optional [tui] extra (not installed in
+# the lint job); yaml and colorama ship no stubs here; portalocker has a
+# try/except ImportError fallback in locking.py, so it may be absent entirely.
+# Ignoring missing imports keeps `mypy csproxy` clean whether or not the
+# interpreter running mypy happens to have these installed.
 [[tool.mypy.overrides]]
-module = ["textual.*", "yaml", "colorama"]
+module = ["textual.*", "yaml", "colorama", "portalocker"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,0 +1,54 @@
+"""Tests for the interactive-prompt helpers (csproxy.utils.interaction).
+
+These guard the regression where a prompt written to a block-buffered stdout
+pipe (e.g. ``cs-proxy delete | tail``) is never shown and the command appears
+to hang. Prompts must go to stderr so they survive stdout redirection.
+"""
+
+import io
+
+from csproxy.utils import eprint, prompt
+from csproxy.utils.interaction import prompt as prompt_direct
+
+
+def test_prompt_writes_message_to_stderr_not_stdout(monkeypatch):
+    out, err = io.StringIO(), io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+    monkeypatch.setattr("builtins.input", lambda: "y")
+
+    answer = prompt("Are you sure? [y/N] ")
+
+    assert answer == "y"
+    assert "Are you sure? [y/N] " in err.getvalue()
+    assert out.getvalue() == ""  # nothing leaks to stdout
+
+
+def test_prompt_returns_line_unstripped(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda: "  WestEurope  ")
+    assert prompt("> ") == "  WestEurope  "
+
+
+def test_prompt_empty_message_does_not_write(monkeypatch):
+    err = io.StringIO()
+    monkeypatch.setattr("sys.stderr", err)
+    monkeypatch.setattr("builtins.input", lambda: "")
+
+    assert prompt() == ""
+    assert err.getvalue() == ""
+
+
+def test_eprint_goes_to_stderr(monkeypatch):
+    out, err = io.StringIO(), io.StringIO()
+    monkeypatch.setattr("sys.stdout", out)
+    monkeypatch.setattr("sys.stderr", err)
+
+    eprint("menu line")
+
+    assert "menu line" in err.getvalue()
+    assert out.getvalue() == ""
+
+
+def test_prompt_is_exported_from_package():
+    # The package re-export and the module object are the same callable.
+    assert prompt is prompt_direct


### PR DESCRIPTION
## Summary
Two follow-ups from manually testing #30's codespace lifecycle.

### 1. Interactive prompts were hidden when stdout is piped
`cs-proxy delete | tail` (and every other prompt) appeared to **hang**: the menu and `Are you sure? [y/N]` were written to stdout via `print()`/`input("…")`, and a piped/block-buffered stdout never flushes them to the terminal while the process blocks on `input()`. No visible question → looks frozen.

**Fix:** new `csproxy/utils/interaction.py` with `prompt()` and `eprint()` that write to **stderr** (the conventional Unix split: data on stdout, human interaction on stderr). Converted every prompt site + its menu lines:
- `proxy.py`: delete, teardown, token entry, keygen regen, split-tunnel, codespace selector
- `codespace.py`: repo / region / selection prompts
- `wg_setup.py`, `wg_routes.py`, `wireguard.py`: selectors and confirmations

No behavior change for a TTY user (stderr and stdout both go to the terminal); prompts now survive `| tail`, `> file`, `$(…)`.

Before/after with stdout sent to `/dev/null`:
```
OLD input():  (blank — prompt swallowed by the pipe)
NEW prompt():  Are you sure? [y/N]
```

### 2. mypy false-positive on portalocker
`locking.py` imports portalocker under `try/except ImportError`, so a mypy run on an interpreter **without** portalocker (e.g. a global/homebrew mypy outside the venv) errored with `import-not-found` even though CI was green. Added `portalocker` to `ignore_missing_imports` so `mypy csproxy` is clean regardless of the interpreter. Verified against both the venv mypy (2.1.0) and homebrew mypy (1.20.2).

## Testing
- New `tests/test_interaction.py` (5 tests): asserts prompts land on stderr, not stdout.
- **138 passed**; `black`/`flake8`/`mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)