### PR TITLE
Fix create_codespace; add codespace creation to the TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ confirmation first):
 | Key | Action |
 |-----|--------|
 | `r` | Refresh now |
+| `c` | Create a codespace (Codespaces tab; prompts for `owner/repo`) |
 | `s` | Start the selected codespace / chain |
 | `x` | Stop the selected tunnel / codespace / chain (confirm) |
 | `d` | Drain the selected tunnel |

--- a/csproxy/github.py
+++ b/csproxy/github.py
@@ -268,31 +268,51 @@ class GitHubManager:
                 return cs
         return None
 
-    def create_codespace(self, repo: Optional[str] = None, machine: str = "2-core") -> dict:
+    def create_codespace(self, repo: Optional[str] = None, machine: str = "basicLinux32gb") -> dict:
         """
         Create a new Codespace.
 
         Args:
-            repo: Repository to create Codespace from (default: auto-detect)
-            machine: Machine type (default: '2-core')
+            repo: Repository to create Codespace from (default: auto-detect from cwd)
+            machine: Machine type (default: 'basicLinux32gb', the smallest standard
+                Linux machine). A concrete value is required: with no ``--machine``,
+                ``gh codespace create`` prompts interactively for it and fails with
+                "error getting machine: no terminal" when run from a non-TTY worker
+                thread or CI. Pass ``""`` to omit the flag (only works with a TTY).
 
         Returns:
-            Created Codespace information dictionary
+            Dict carrying the new Codespace's ``name``.
 
         Raises:
             subprocess.CalledProcessError: If creation fails
-        """
-        args = ["codespace", "create", "--machine", machine, "--json", "name,state"]
+            RuntimeError: If gh succeeds but no codespace name can be parsed
 
+        Note:
+            Unlike ``codespace list``/``view``, ``gh codespace create`` has no
+            ``--json`` flag — it prints the new codespace's name to stdout (status
+            and billing banners go to stderr), so we read the name from stdout.
+        """
+        args = ["codespace", "create"]
+        if machine:
+            args.extend(["--machine", machine])
         if repo:
             args.extend(["--repo", repo])
 
-        self.logger.info(f"Creating new Codespace (machine: {machine})...")
+        self.logger.info(f"Creating new Codespace (machine: {machine or 'gh-default'})...")
         result = self.run_gh_command(args)
-        codespace: dict = json.loads(result.stdout)
 
-        self.logger.info(f"Created Codespace: {codespace['name']}")
-        return codespace
+        # stdout is just the codespace name; take the last non-empty line in case
+        # anything else leaks onto stdout.
+        name = ""
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if stripped:
+                name = stripped
+        if not name:
+            raise RuntimeError("gh codespace create returned no codespace name")
+
+        self.logger.info(f"Created Codespace: {name}")
+        return {"name": name}
 
     def delete_codespace(self, name: str, force: bool = False) -> None:
         """

--- a/csproxy/tui/app.py
+++ b/csproxy/tui/app.py
@@ -4,9 +4,10 @@ Textual app for csproxy — a live monitor with actions.
 
 Renders the same structured data the CLI uses (via csproxy.services), refreshing
 on a timer, and drives the same service layer for mutating actions (stop/drain/
-rotate tunnels; start/stop/delete codespaces). All blocking work (gh/ssh/curl
-subprocess calls) runs in threaded workers so the UI never freezes, and
-destructive actions are gated behind a confirmation modal.
+rotate tunnels; create/start/stop/delete codespaces). All blocking work (gh/ssh/
+curl subprocess calls) runs in threaded workers so the UI never freezes,
+destructive actions are gated behind a confirmation modal, and create prompts
+for its repo through an input modal.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from textual.widgets import (
     DataTable,
     Footer,
     Header,
+    Input,
     Label,
     Log,
     Static,
@@ -86,6 +88,64 @@ class ConfirmScreen(ModalScreen[bool]):
         self.dismiss(False)
 
 
+class InputScreen(ModalScreen[Optional[str]]):
+    """A small text-input modal. Dismisses with the entered text, or None on
+    cancel/empty. Used to collect e.g. the repo for a codespace create."""
+
+    CSS = """
+    InputScreen { align: center middle; }
+    #idialog {
+        grid-size: 2;
+        grid-gutter: 1 2;
+        grid-rows: 1fr 3 3;
+        padding: 1 2;
+        width: 70;
+        height: 14;
+        border: thick $background 80%;
+        background: $surface;
+    }
+    #iprompt { column-span: 2; height: 1fr; content-align: center middle; }
+    #ivalue { column-span: 2; }
+    Button { width: 100%; }
+    """
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(self, prompt: str, value: str = "", placeholder: str = "") -> None:
+        super().__init__()
+        self._prompt = prompt
+        self._value = value
+        self._placeholder = placeholder
+
+    def compose(self) -> ComposeResult:
+        yield Grid(
+            Label(self._prompt, id="iprompt"),
+            Input(value=self._value, placeholder=self._placeholder, id="ivalue"),
+            Button("OK", variant="primary", id="ok"),
+            Button("Cancel", variant="default", id="cancel"),
+            id="idialog",
+        )
+
+    def on_mount(self) -> None:
+        self.query_one("#ivalue", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self._submit()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ok":
+            self._submit()
+        else:
+            self.dismiss(None)
+
+    def _submit(self) -> None:
+        value: str = self.query_one("#ivalue", Input).value.strip()
+        self.dismiss(value or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
 class CsProxyTUI(App):
     """Live monitor + actions for tunnels, codespaces, diagnostics, and logs."""
 
@@ -100,6 +160,7 @@ class CsProxyTUI(App):
 
     BINDINGS = [
         ("r", "refresh", "Refresh"),
+        ("c", "create", "Create"),
         ("s", "start", "Start"),
         ("x", "stop", "Stop"),
         ("d", "drain", "Drain"),
@@ -198,7 +259,7 @@ class CsProxyTUI(App):
                 f"{len(data['tunnels'])} tunnel(s) · "
                 f"{len(data['codespaces'])} codespace(s) · "
                 f"{len(self._chains)} chain(s) · "
-                f"{failures} check failure(s)  —  s/x/d/o/Del to act, r refresh, q quit"
+                f"{failures} check failure(s)  —  c new, s/x/d/o/Del to act, r refresh, q quit"
             )
 
     # ------------------------------------------------------------------
@@ -241,6 +302,35 @@ class CsProxyTUI(App):
                 lambda: stop_chain(self._config, self._gh, name),
                 f"Stopped chain {name}",
             )
+
+    def action_create(self) -> None:
+        if self._active_tab() != "tab-codespaces":
+            self.notify("Switch to the Codespaces tab to create one", severity="warning")
+            return
+
+        # Prefill from config if set, else a public template that always supports
+        # Codespaces so the field is never empty.
+        default_repo: str = str(self._config.get("codespace_repo", "") or "") or (
+            "github/codespaces-blank"
+        )
+
+        def on_result(repo: Optional[str]) -> None:
+            if not repo:
+                return
+            self.notify(f"Creating codespace from {repo}… this can take a minute")
+            self._perform(
+                lambda: self._gh.create_codespace(repo=repo),
+                f"Created codespace from {repo}",
+            )
+
+        self.push_screen(
+            InputScreen(
+                "Create codespace from repository (owner/repo):",
+                value=default_repo,
+                placeholder="owner/repo",
+            ),
+            on_result,
+        )
 
     def action_start(self) -> None:
         tab = self._active_tab()
@@ -317,18 +407,18 @@ class CsProxyTUI(App):
     # Action plumbing.
     # ------------------------------------------------------------------
 
-    def _confirm(self, question: str, fn: Callable[[], None], success: str) -> None:
+    def _confirm(self, question: str, fn: Callable[[], object], success: str) -> None:
         def on_result(confirmed: Optional[bool]) -> None:
             if confirmed:
                 self._perform(fn, success)
 
         self.push_screen(ConfirmScreen(question), on_result)
 
-    def _perform(self, fn: Callable[[], None], success: str) -> None:
+    def _perform(self, fn: Callable[[], object], success: str) -> None:
         self._run_action(fn, success)
 
     @work(thread=True, group="action")
-    def _run_action(self, fn: Callable[[], None], success: str) -> None:
+    def _run_action(self, fn: Callable[[], object], success: str) -> None:
         try:
             fn()
             self.call_from_thread(self._action_done, success, None)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,76 @@
+"""Tests for GitHubManager codespace lifecycle helpers."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from csproxy.github import GitHubManager
+
+
+def _gh(tmp_path):
+    return GitHubManager(config_dir=tmp_path)
+
+
+def _result(stdout="", stderr=""):
+    return MagicMock(returncode=0, stdout=stdout, stderr=stderr)
+
+
+def test_create_codespace_parses_name_and_never_passes_json(tmp_path):
+    gh = _gh(tmp_path)
+    gh.runner.run = MagicMock(return_value=_result(stdout="cautious-meme-abc123\n"))
+
+    cs = gh.create_codespace(repo="owner/repo", machine="basicLinux32gb")
+
+    assert cs == {"name": "cautious-meme-abc123"}
+    cmd = gh.runner.run.call_args.args[0]
+    # gh codespace create has no --json flag (only list/view do); never pass it.
+    assert "--json" not in cmd
+    assert cmd[:3] == ["gh", "codespace", "create"]
+    assert "--repo" in cmd and "owner/repo" in cmd
+    assert "--machine" in cmd and "basicLinux32gb" in cmd
+
+
+def test_create_codespace_reads_name_from_stdout_only(tmp_path):
+    gh = _gh(tmp_path)
+    # gh prints billing/status banners to stderr; only stdout carries the name.
+    gh.runner.run = MagicMock(
+        return_value=_result(
+            stdout="\nfriendly-name-xyz\n",
+            stderr="✓ Codespaces usage for this repository is paid for by acme\n",
+        )
+    )
+
+    cs = gh.create_codespace(repo="owner/repo")
+
+    assert cs["name"] == "friendly-name-xyz"
+    # No machine given -> default to a concrete machine (gh would otherwise
+    # prompt interactively and fail with "no terminal" in a worker/CI).
+    cmd = gh.runner.run.call_args.args[0]
+    assert "--machine" in cmd and "basicLinux32gb" in cmd
+
+
+def test_create_codespace_omits_machine_when_blank(tmp_path):
+    gh = _gh(tmp_path)
+    gh.runner.run = MagicMock(return_value=_result(stdout="tty-created-cs\n"))
+
+    gh.create_codespace(repo="owner/repo", machine="")
+
+    # Explicit empty machine opts out of the flag (caller has a TTY).
+    assert "--machine" not in gh.runner.run.call_args.args[0]
+
+
+def test_create_codespace_omits_repo_when_none(tmp_path):
+    gh = _gh(tmp_path)
+    gh.runner.run = MagicMock(return_value=_result(stdout="auto-detected-cs\n"))
+
+    gh.create_codespace()
+
+    assert "--repo" not in gh.runner.run.call_args.args[0]
+
+
+def test_create_codespace_raises_when_no_name(tmp_path):
+    gh = _gh(tmp_path)
+    gh.runner.run = MagicMock(return_value=_result(stdout="\n   \n"))
+
+    with pytest.raises(RuntimeError):
+        gh.create_codespace(repo="owner/repo")

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -10,7 +10,7 @@ pytest.importorskip("textual")
 from csproxy.github import GitHubManager  # noqa: E402
 from csproxy.services import Check  # noqa: E402
 from csproxy.state import State  # noqa: E402
-from csproxy.tui.app import ConfirmScreen, CsProxyTUI  # noqa: E402
+from csproxy.tui.app import ConfirmScreen, CsProxyTUI, InputScreen  # noqa: E402
 from csproxy.utils import Config  # noqa: E402
 from textual.worker import WorkerCancelled  # noqa: E402
 
@@ -267,5 +267,97 @@ def test_tui_chain_delete_confirm_invokes_service():
                 await _settle(app)
                 await pilot.pause()
             mock_delete.assert_called_once()
+
+    asyncio.run(scenario())
+
+
+def test_tui_create_prompts_and_invokes_gh():
+    async def scenario():
+        from textual.widgets import Input, TabbedContent
+
+        app = _app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.query_one(TabbedContent).active = "tab-codespaces"
+            await pilot.pause()
+
+            with patch.object(
+                app._gh, "create_codespace", return_value={"name": "new-cs"}
+            ) as mock_create:
+                await pilot.press("c")  # open the input modal
+                await pilot.pause()
+                assert isinstance(app.screen, InputScreen)
+
+                # Type a repo and submit with Enter (the real input path).
+                app.screen.query_one("#ivalue", Input).value = "owner/repo"
+                await pilot.press("enter")
+                await _settle(app)
+                await pilot.pause()
+
+            mock_create.assert_called_once()
+            assert mock_create.call_args.kwargs.get("repo") == "owner/repo"
+
+    asyncio.run(scenario())
+
+
+def test_tui_create_defaults_to_codespaces_blank():
+    async def scenario():
+        from textual.widgets import Input, TabbedContent
+
+        app = _app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.query_one(TabbedContent).active = "tab-codespaces"
+            await pilot.pause()
+
+            with patch.object(
+                app._gh, "create_codespace", return_value={"name": "blank-cs"}
+            ) as mock_create:
+                await pilot.press("c")
+                await pilot.pause()
+                # Field is prefilled with the public template; accept it as-is.
+                assert app.screen.query_one("#ivalue", Input).value == "github/codespaces-blank"
+                await pilot.press("enter")
+                await _settle(app)
+                await pilot.pause()
+
+            assert mock_create.call_args.kwargs.get("repo") == "github/codespaces-blank"
+
+    asyncio.run(scenario())
+
+
+def test_tui_create_empty_input_does_nothing():
+    async def scenario():
+        from textual.widgets import TabbedContent
+
+        app = _app()
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.query_one(TabbedContent).active = "tab-codespaces"
+            await pilot.pause()
+
+            with patch.object(app._gh, "create_codespace") as mock_create:
+                await pilot.press("c")
+                await pilot.pause()
+                assert isinstance(app.screen, InputScreen)
+                app.screen.dismiss(None)  # cancel / empty -> no create
+                await _settle(app)
+                await pilot.pause()
+            mock_create.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+def test_tui_create_warns_off_codespaces_tab():
+    async def scenario():
+        app = _app()
+        async with app.run_test() as pilot:
+            await pilot.pause()  # default tab is Tunnels
+            with patch.object(app._gh, "create_codespace") as mock_create:
+                await pilot.press("c")
+                await pilot.pause()
+                # No input modal on the wrong tab, and no create attempted.
+                assert not isinstance(app.screen, InputScreen)
+            mock_create.assert_not_called()
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Summary

Two related changes — a bug fix that makes codespace creation work at all, and a TUI feature built on top of it.

### Fix `create_codespace` (`csproxy/github.py`)
`create_codespace` passed `--json name,state` to `gh codespace create`, but **`gh codespace create` has no `--json` flag** (only `list`/`view` do) — every call failed with `unknown flag: --json`. It had no callers and no tests, so the breakage was invisible. Fixes:
- Read the new codespace **name from stdout** (gh prints status/billing banners to stderr).
- Default to a **concrete machine** (`basicLinux32gb`). Without `--machine`, gh prompts interactively and dies with `error getting machine: no terminal` in a non-TTY worker/CI. The old `2-core` default wasn't a valid machine name either. Pass `machine=""` to opt out (TTY only).
- Raise a clear `RuntimeError` if gh succeeds but no name can be parsed.

### Add Create to the TUI (`csproxy/tui/app.py`)
- New `c` Create binding on the **Codespaces** tab.
- Opens a text-input modal (`InputScreen`) prefilled with `github/codespaces-blank` (override via the `codespace_repo` config key).
- Provisions in a threaded worker like the other actions (UI never freezes), notifies, and refreshes on success.

## Testing
- New `tests/test_github.py`: arg-building (never passes `--json`, defaults machine, omits `--repo`/`--machine` appropriately) and stdout name parsing.
- `tests/test_tui.py`: create prompt invokes gh with the typed repo, default-repo prefill, empty-input/cancel does nothing, wrong-tab guard.
- All gates clean locally: **165 passed**, black / flake8 / mypy.
- **Verified live end-to-end** against real Codespaces (`encountercritical` account): `c` → modal → create from `github/codespaces-blank` → `Available` in the TUI → `Del` → gone.

## Notes
The `create_codespace` bug and the missing TUI create were both found while live-testing #32's stop/delete actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)