### PR TITLE
feat: add cs-mcp MCP server exposing the toolkit to MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Full documentation at **[https://dstours.github.io/fluffy-barnacle/](https://dst
 | **cs-serve** | Instant public HTTPS file hosting, redirect servers, custom HTTP responses, and data capture via `*.app.github.dev` |
 | **cs-wg** | Full WireGuard VPN tunnel with route management and traffic monitoring |
 | **cs-tools** | Drop-in wrappers for nmap, ffuf, httpx, nuclei, sqlmap with automatic SOCKS5 proxy arguments and smart tunnel rotation |
+| **cs-mcp** | Model Context Protocol server exposing the toolkit to MCP-aware clients (Claude Desktop, Claude Code, Cursor) |
 
 Codespace IPs rotate on each creation, giving you fresh egress IPs on demand. Each tool works from the CLI or as a Python library.
 

--- a/csproxy/mcp/__init__.py
+++ b/csproxy/mcp/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Model Context Protocol (MCP) server for csproxy (optional `mcp` extra).
+
+Exposes the same operations as the CLI and TUI over MCP so the toolkit can be
+driven from MCP-aware clients (Claude Desktop, Claude Code, Cursor, ...). The
+heavy `mcp` SDK import lives in `.server`; this launcher keeps it lazy so the
+package imports fine without the SDK installed and prints a friendly hint when
+the extra is missing -- mirroring the `tui` launcher.
+"""
+
+from __future__ import annotations
+
+
+def main_mcp(argv=None) -> int:
+    """Entry point for the `cs-mcp` command. Runs the MCP server over stdio."""
+    try:
+        from .server import run_server
+    except ImportError as e:  # mcp SDK not installed
+        if "mcp" in str(e).lower():
+            print(
+                "The cs-mcp server requires the optional 'mcp' extra.\n"
+                "Install it with:  pip install 'fluffy-barnacle[mcp]'"
+            )
+            return 1
+        raise
+    return run_server(argv)

--- a/csproxy/mcp/server.py
+++ b/csproxy/mcp/server.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+FastMCP server wrapping the csproxy service layer.
+
+This module is a thin MCP front-end: every tool delegates to ``csproxy.services``
+(the presentation-free, structured-data API) or to ``GitHubManager``. No core
+logic is reimplemented here, so behaviour stays identical across the CLI, the
+TUI, and MCP. Service functions return plain data and raise on error; FastMCP
+turns a raised exception into an MCP tool error, so the wrappers stay tiny.
+
+Transport is stdio only (local, single-client). The toolkit provisions real
+GitHub Codespaces infrastructure under GitHub's Codespaces Terms of Service, so
+destructive tools (`delete_codespace`, `stop_all_tunnels`, `stop_chain`,
+`delete_chain`) are clearly marked in their docstrings; well-behaved MCP clients
+surface those descriptions and confirm before calling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import asdict
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ..github import GitHubManager
+from ..utils import Config
+from .. import services
+
+
+def _context() -> tuple[Config, GitHubManager]:
+    """Build a fresh Config + GitHubManager, mirroring the CLI entry points.
+
+    Built per call rather than cached so each tool invocation sees current
+    on-disk config/state (the CLI and TUI may mutate it between calls) and so a
+    transient failure never leaves a poisoned singleton behind.
+    """
+    config = Config()
+    config.ensure_dirs()
+    gh = GitHubManager(config_dir=config.config_dir)
+    return config, gh
+
+
+def build_server() -> FastMCP:
+    """Construct the FastMCP server with all tools and resources registered."""
+    mcp = FastMCP("cs-mcp")
+
+    # ----------------------------------------------------------------- reads
+    @mcp.tool()
+    def diagnostics() -> list[dict]:
+        """Run dependency/configuration health checks (the `cs-proxy check` set).
+
+        Returns a list of {status: "PASS"|"FAIL", message} entries.
+        """
+        config, gh = _context()
+        return [asdict(c) for c in services.run_diagnostics(config, gh)]
+
+    @mcp.tool()
+    def list_pool(reconcile: bool = True) -> list[dict]:
+        """List tracked SSH proxy tunnels from the state store.
+
+        Set reconcile=True (default) to mark dead-PID tunnels crashed first so
+        statuses are fresh. Each entry carries id/kind/port/pid/status/
+        codespace_name/failures.
+        """
+        config, _ = _context()
+        return services.list_pool(config, reconcile=reconcile)
+
+    @mcp.tool()
+    def list_codespaces() -> list[dict]:
+        """List the authenticated user's GitHub Codespaces (best effort).
+
+        Returns [] rather than erroring if gh is missing or unauthenticated.
+        """
+        _, gh = _context()
+        return services.list_codespaces_safe(gh)
+
+    @mcp.tool()
+    def get_codespace(name: str) -> Optional[dict]:
+        """Get a single Codespace by name, or null if it does not exist."""
+        _, gh = _context()
+        return gh.get_codespace(name)
+
+    @mcp.tool()
+    def get_logs(lines: int = 50) -> list[str]:
+        """Return the last `lines` lines of the proxy log ([] if none)."""
+        config, _ = _context()
+        return services.get_logs(config, lines=lines)
+
+    @mcp.tool()
+    def list_chains() -> list[dict]:
+        """List two-hop Codespace chains (defined + running, combined view)."""
+        config, _ = _context()
+        return services.list_chains(config)
+
+    # ------------------------------------------------------- tunnel actions
+    @mcp.tool()
+    def stop_tunnel(port: int) -> str:
+        """Stop the SSH tunnel bound to `port` and remove it from the pool."""
+        config, _ = _context()
+        services.stop_tunnel(config, port)
+        return f"Stopped tunnel on port {port}"
+
+    @mcp.tool()
+    def drain_tunnel(port: int) -> str:
+        """Mark the tunnel on `port` as draining (stops taking new traffic)."""
+        config, _ = _context()
+        services.drain_tunnel(config, port)
+        return f"Tunnel on port {port} marked draining"
+
+    @mcp.tool()
+    def rotate_pool() -> int:
+        """Return a random healthy tunnel port. Errors if none are healthy."""
+        config, _ = _context()
+        return services.rotate_pool(config)
+
+    @mcp.tool()
+    def stop_all_tunnels() -> str:
+        """DESTRUCTIVE. Stop the primary tunnel, all pool tunnels, and the HTTP
+        proxy. Tears down all local proxy forwarding at once."""
+        config, _ = _context()
+        services.stop_all_tunnels(config)
+        return "Stopped all tunnels and the HTTP proxy"
+
+    # -------------------------------------------------------- chain actions
+    @mcp.tool()
+    def start_chain(name: str, port: Optional[int] = None) -> str:
+        """Start a defined two-hop chain. Slow: provisions/links two hops."""
+        config, gh = _context()
+        services.start_chain(config, gh, name, port=port)
+        return f"Started chain {name}"
+
+    @mcp.tool()
+    def stop_chain(name: str) -> str:
+        """DESTRUCTIVE. Stop a running chain and clean up its remote relays."""
+        config, gh = _context()
+        services.stop_chain(config, gh, name)
+        return f"Stopped chain {name}"
+
+    @mcp.tool()
+    def delete_chain(name: str) -> str:
+        """DESTRUCTIVE. Remove a chain definition from config. Errors if unknown."""
+        config, _ = _context()
+        services.delete_chain(config, name)
+        return f"Deleted chain definition {name}"
+
+    # ----------------------------------------------------- codespace actions
+    @mcp.tool()
+    def create_codespace(repo: Optional[str] = None, machine: str = "basicLinux32gb") -> dict:
+        """Create a new GitHub Codespace (provisions real, billable infra).
+
+        repo defaults to auto-detecting from the current directory. machine
+        defaults to the smallest standard Linux machine; pass "" only with a TTY.
+        Returns {"name": <new codespace name>}.
+        """
+        _, gh = _context()
+        return gh.create_codespace(repo=repo, machine=machine)
+
+    @mcp.tool()
+    def delete_codespace(name: str, force: bool = False) -> str:
+        """DESTRUCTIVE. Permanently delete a Codespace. Set force=True to skip
+        gh's confirmation prompt (required when running non-interactively)."""
+        _, gh = _context()
+        gh.delete_codespace(name, force=force)
+        return f"Deleted codespace {name}"
+
+    @mcp.tool()
+    def start_codespace(name: str) -> str:
+        """Start a stopped Codespace."""
+        _, gh = _context()
+        gh.start_codespace(name)
+        return f"Started codespace {name}"
+
+    @mcp.tool()
+    def stop_codespace(name: str) -> str:
+        """Stop a running Codespace (preserves it; does not delete)."""
+        _, gh = _context()
+        gh.stop_codespace(name)
+        return f"Stopped codespace {name}"
+
+    # ------------------------------------------------------------ resources
+    @mcp.resource("cs://pool")
+    def pool_resource() -> list[dict]:
+        """Current SSH tunnel pool (reconciled), as a readable resource."""
+        config, _ = _context()
+        return services.list_pool(config, reconcile=True)
+
+    @mcp.resource("cs://codespaces")
+    def codespaces_resource() -> list[dict]:
+        """Current GitHub Codespaces (best effort), as a readable resource."""
+        _, gh = _context()
+        return services.list_codespaces_safe(gh)
+
+    return mcp
+
+
+def run_server(argv=None) -> int:
+    """Parse args and run the MCP server over stdio."""
+    parser = argparse.ArgumentParser(
+        prog="cs-mcp",
+        description="MCP server exposing the csproxy toolkit to MCP-aware clients (stdio).",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose logging")
+    args = parser.parse_args(argv)
+
+    # Log to stderr only -- stdout is the MCP stdio transport and must stay
+    # clean. csproxy.setup_logger() hardcodes a stdout handler and no-ops once
+    # the logger already has handlers, so we install a stderr handler first to
+    # win that race and keep stdout pristine.
+    logger = logging.getLogger("csproxy")
+    if not logger.handlers:
+        logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
+        logger.propagate = False
+        handler = logging.StreamHandler(sys.stderr)
+        handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+        logger.addHandler(handler)
+
+    build_server().run(transport="stdio")
+    return 0

--- a/docs/user-guide/command-reference/cs-mcp.md
+++ b/docs/user-guide/command-reference/cs-mcp.md
@@ -1,0 +1,71 @@
+# cs-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the csproxy toolkit to MCP-aware clients (Claude Desktop, Claude Code, Cursor, and any other MCP host). It wraps the same presentation-free service layer as the CLI and TUI, so anything you do through MCP is reflected by `cs-proxy` and vice versa — no logic is reimplemented, only adapted to MCP tools and resources.
+
+The server ships as an optional extra (it pulls in the official `mcp` SDK):
+
+```bash
+pip install 'fluffy-barnacle[mcp]'   # one-time: install the optional MCP extra
+cs-mcp                               # run the server over stdio
+```
+
+`cs-mcp` speaks the **stdio** transport: it reads JSON-RPC on stdin and writes on stdout, and is meant to be launched by an MCP client rather than run by hand. (Running it in a terminal will simply wait for a client to connect.) Logs go to stderr so the transport on stdout stays clean.
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `diagnostics` | Dependency/config health checks (same set as `cs-proxy check`) |
+| `list_pool` | List tracked SSH proxy tunnels (optionally reconciling dead PIDs) |
+| `list_codespaces` | List your GitHub Codespaces (best effort) |
+| `get_codespace` | Look up a single codespace by name |
+| `get_logs` | Tail `proxy.log` |
+| `list_chains` | List defined + running two-hop chains |
+| `stop_tunnel` | Stop the tunnel on a port and remove it from the pool |
+| `drain_tunnel` | Mark a tunnel draining |
+| `rotate_pool` | Return a random healthy tunnel port |
+| `stop_all_tunnels` | **Destructive** — stop all tunnels and the HTTP proxy |
+| `start_chain` | Start a defined two-hop chain |
+| `stop_chain` | **Destructive** — stop a running chain and clean up relays |
+| `delete_chain` | **Destructive** — remove a chain definition |
+| `create_codespace` | Provision a new Codespace (real, billable infra) |
+| `delete_codespace` | **Destructive** — permanently delete a Codespace |
+| `start_codespace` | Start a stopped Codespace |
+| `stop_codespace` | Stop a running Codespace (keeps it) |
+
+Destructive tools are flagged as such in their descriptions; well-behaved MCP clients surface that and confirm before calling.
+
+## Resources
+
+| URI | Contents |
+|-----|----------|
+| `cs://pool` | The current SSH tunnel pool (reconciled) |
+| `cs://codespaces` | Your current GitHub Codespaces |
+
+Resources let a client pull read-only state without invoking a tool.
+
+## Connecting a client
+
+**Claude Code** — register the server once:
+
+```bash
+claude mcp add cs-proxy -- cs-mcp
+```
+
+**Claude Desktop / Cursor** — add an entry to the client's MCP config (e.g. `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cs-proxy": {
+      "command": "cs-mcp"
+    }
+  }
+}
+```
+
+If `cs-mcp` is not on the client's `PATH` (for example when it runs outside your shell environment), point `command` at the absolute path inside your virtualenv — e.g. `/path/to/.venv/bin/cs-mcp`.
+
+## Prerequisites
+
+`cs-mcp` runs the same operations as the CLI, so it needs the same setup: the GitHub CLI (`gh`) installed and authenticated, and an SSH key generated (`cs-proxy keygen`). Run the `diagnostics` tool first to confirm the environment is ready.

--- a/docs/user-guide/command-reference/index.md
+++ b/docs/user-guide/command-reference/index.md
@@ -11,6 +11,7 @@ cs-proxy provides five commands, each with its own set of subcommands.
 | [cs-wg](cs-wg.md) | `sudo cs-wg <command>` | WireGuard VPN tunnel management |
 | [cs-tools](cs-tools.md) | `cs-tools <tool> [args]` | Proxied security tool wrappers with smart tunnel rotation |
 | [cs-tui](cs-tui.md) | `cs-tui` | Interactive terminal dashboard to monitor and manage tunnels, codespaces, and chains |
+| [cs-mcp](cs-mcp.md) | `cs-mcp` | MCP server exposing the toolkit to MCP-aware clients (Claude Desktop, Claude Code, Cursor) |
 
 ## Global Options
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -51,6 +51,16 @@ pip install -e ".[tui]"
 This adds [Textual](https://textual.textualize.io/), required by the `cs-tui`
 dashboard. See [cs-tui](command-reference/cs-tui.md) for usage.
 
+### With the MCP server
+
+```bash
+pip install -e ".[mcp]"
+```
+
+This adds the official [`mcp`](https://github.com/modelcontextprotocol/python-sdk)
+SDK, required by the `cs-mcp` server that exposes the toolkit to MCP-aware
+clients. See [cs-mcp](command-reference/cs-mcp.md) for usage.
+
 ### Virtual Environment
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - cs-wg: user-guide/command-reference/cs-wg.md
       - cs-tools: user-guide/command-reference/cs-tools.md
       - cs-tui: user-guide/command-reference/cs-tui.md
+      - cs-mcp: user-guide/command-reference/cs-mcp.md
   - Use Cases:
     - Overview: use-cases/index.md
     - Proxy Rotation: use-cases/proxy-rotation.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ dev = [
 tui = [
     "textual>=0.60",
 ]
+mcp = [
+    # v2 is planned for Q1 and may carry breaking changes; pin to the stable v1
+    # line. FastMCP (used by csproxy.mcp.server) ships inside this package.
+    "mcp>=1.25,<2",
+]
 docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",
@@ -66,6 +71,7 @@ cs-serve = "csproxy.cli:main_serve"
 cs-wg = "csproxy.cli:main_wg"
 cs-tools = "csproxy.tools:main_tools"
 cs-tui = "csproxy.tui:main_tui"
+cs-mcp = "csproxy.mcp:main_mcp"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -88,7 +94,7 @@ disallow_untyped_defs = false
 # Ignoring missing imports keeps `mypy csproxy` clean whether or not the
 # interpreter running mypy happens to have these installed.
 [[tool.mypy.overrides]]
-module = ["textual.*", "yaml", "colorama", "portalocker"]
+module = ["textual.*", "mcp.*", "yaml", "colorama", "portalocker"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,121 @@
+"""Tests for the MCP server front-end (csproxy.mcp.server).
+
+These assert the server registers the expected tools/resources and that each
+tool delegates to the service layer / GitHubManager rather than reimplementing
+logic. Heavy work (gh, ssh) is mocked at the csproxy.mcp.server seam.
+
+Skipped entirely if the optional `mcp` extra is not installed.
+"""
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("mcp", reason="requires the optional 'mcp' extra")
+
+from csproxy.mcp.server import build_server  # noqa: E402
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _result_json(call_tool_return):
+    """Pull the payload out of a FastMCP low-level call_tool() return.
+
+    The SDK returns either a bare content list or a (content, structured) tuple
+    depending on the tool's return type, so parse the always-present TextContent
+    JSON rather than depending on the structured half's shape.
+    """
+    import json
+
+    if isinstance(call_tool_return, tuple):
+        structured = call_tool_return[1]
+        # FastMCP wraps non-object returns (lists, scalars) under "result".
+        if isinstance(structured, dict) and set(structured) == {"result"}:
+            return structured["result"]
+        return structured
+    return json.loads(call_tool_return[0].text)
+
+
+EXPECTED_TOOLS = {
+    "diagnostics",
+    "list_pool",
+    "list_codespaces",
+    "get_codespace",
+    "get_logs",
+    "list_chains",
+    "stop_tunnel",
+    "drain_tunnel",
+    "rotate_pool",
+    "stop_all_tunnels",
+    "start_chain",
+    "stop_chain",
+    "delete_chain",
+    "create_codespace",
+    "delete_codespace",
+    "start_codespace",
+    "stop_codespace",
+}
+
+
+def test_all_tools_registered():
+    server = build_server()
+    names = {t.name for t in _run(server.list_tools())}
+    assert EXPECTED_TOOLS <= names
+
+
+def test_resources_registered():
+    server = build_server()
+    uris = {str(r.uri) for r in _run(server.list_resources())}
+    assert {"cs://pool", "cs://codespaces"} <= uris
+
+
+def test_destructive_tools_flagged_in_description():
+    """delete/stop-all tools must carry a DESTRUCTIVE marker so MCP clients
+    surface a warning before calling them."""
+    server = build_server()
+    by_name = {t.name: t for t in _run(server.list_tools())}
+    for name in ("delete_codespace", "stop_all_tunnels", "stop_chain", "delete_chain"):
+        assert "DESTRUCTIVE" in (by_name[name].description or "")
+
+
+def test_diagnostics_delegates_to_service(monkeypatch):
+    import csproxy.mcp.server as srv
+    from csproxy.services import Check
+
+    sentinel = [Check("PASS", "looks good")]
+    monkeypatch.setattr(srv.services, "run_diagnostics", lambda config, gh: sentinel)
+
+    server = build_server()
+    payload = _result_json(_run(server.call_tool("diagnostics", {})))
+    assert payload == [{"status": "PASS", "message": "looks good"}]
+
+
+def test_create_codespace_delegates_to_gh(monkeypatch):
+    import csproxy.mcp.server as srv
+
+    class FakeGH:
+        def create_codespace(self, repo=None, machine="basicLinux32gb"):
+            return {"name": f"cs-{machine}"}
+
+    monkeypatch.setattr(srv, "_context", lambda: (object(), FakeGH()))
+
+    server = build_server()
+    payload = _result_json(
+        _run(server.call_tool("create_codespace", {"machine": "basicLinux32gb"}))
+    )
+    assert payload == {"name": "cs-basicLinux32gb"}
+
+
+def test_stop_tunnel_delegates_to_service(monkeypatch):
+    import csproxy.mcp.server as srv
+
+    calls = {}
+    monkeypatch.setattr(
+        srv.services, "stop_tunnel", lambda config, port: calls.setdefault("port", port)
+    )
+
+    server = build_server()
+    _run(server.call_tool("stop_tunnel", {"port": 1080}))
+    assert calls["port"] == 1080


### PR DESCRIPTION
## Summary

Adds a Model Context Protocol server (`cs-mcp`) so the csproxy toolkit can be driven from MCP-aware clients (Claude Desktop, Claude Code, Cursor, …).

The server is a thin front-end over the existing presentation-free service layer (`csproxy.services`) and `GitHubManager` — no core logic is reimplemented, so behavior stays identical across the CLI, TUI, and MCP. It exposes **17 tools** (diagnostics, tunnel pool actions, two-hop chains, and the full codespace lifecycle) plus **`cs://pool`** and **`cs://codespaces`** resources over the **stdio** transport. Destructive tools are flagged in their descriptions so clients confirm before calling.

## Changes
- `csproxy/mcp/` — lazy launcher (mirrors the `tui` extra) + FastMCP server
- `pyproject.toml` — `mcp` optional extra (`mcp>=1.25,<2`), `cs-mcp` console script, mypy override for `mcp.*`
- `tests/test_mcp.py` — tool/resource registration + delegation to the service layer (skipped if the extra is absent)
- docs — `cs-mcp` command reference, nav, README/index/installation entries

Logs are routed to **stderr** so the stdio transport on stdout stays clean.

## Testing
- **Live end-to-end**: spawned the real `cs-mcp` binary and drove it over the actual stdio JSON-RPC protocol with the official MCP client SDK — `initialize` → list 17 tools → list 2 resources → call `diagnostics` (ran the real service layer incl. live `gh auth status`, 11 checks) → `list_pool` → read `cs://pool`. All clean.
- black, flake8, mypy clean; **171 tests pass** (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)