### PR TITLE
fix(codespace): default create_codespace to github/codespaces-blank

### DIFF
--- a/csproxy/github.py
+++ b/csproxy/github.py
@@ -273,7 +273,9 @@ class GitHubManager:
         Create a new Codespace.
 
         Args:
-            repo: Repository to create Codespace from (default: auto-detect from cwd)
+            repo: Repository to create Codespace from (default: ``github/codespaces-blank``,
+                GitHub's blank template — a generic Ubuntu Codespace, which is exactly
+                what the SOCKS relay needs and works headlessly with no local repo)
             machine: Machine type (default: 'basicLinux32gb', the smallest standard
                 Linux machine). A concrete value is required: with no ``--machine``,
                 ``gh codespace create`` prompts interactively for it and fails with
@@ -292,11 +294,15 @@ class GitHubManager:
             ``--json`` flag — it prints the new codespace's name to stdout (status
             and billing banners go to stderr), so we read the name from stdout.
         """
+        # Default to GitHub's blank template repo. Without --repo, `gh codespace
+        # create` auto-detects from the cwd — which fails headlessly (the worker's
+        # cwd is not a Codespaces-enabled repo) and pushes callers to guess a repo
+        # name. The blank repo is exactly what a SOCKS relay needs (generic Ubuntu).
+        repo = repo or "github/codespaces-blank"
         args = ["codespace", "create"]
         if machine:
             args.extend(["--machine", machine])
-        if repo:
-            args.extend(["--repo", repo])
+        args.extend(["--repo", repo])
 
         self.logger.info(f"Creating new Codespace (machine: {machine or 'gh-default'})...")
         result = self.run_gh_command(args)

--- a/csproxy/mcp/server.py
+++ b/csproxy/mcp/server.py
@@ -151,9 +151,10 @@ def build_server() -> FastMCP:
     def create_codespace(repo: Optional[str] = None, machine: str = "basicLinux32gb") -> dict:
         """Create a new GitHub Codespace (provisions real, billable infra).
 
-        repo defaults to auto-detecting from the current directory. machine
-        defaults to the smallest standard Linux machine; pass "" only with a TTY.
-        Returns {"name": <new codespace name>}.
+        repo defaults to ``github/codespaces-blank`` (GitHub's blank template — a
+        generic Ubuntu Codespace, which is what the SOCKS relay wants and works
+        with no local repo). machine defaults to the smallest standard Linux
+        machine; pass "" only with a TTY. Returns {"name": <new codespace name>}.
         """
         _, gh = _context()
         return gh.create_codespace(repo=repo, machine=machine)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -59,13 +59,17 @@ def test_create_codespace_omits_machine_when_blank(tmp_path):
     assert "--machine" not in gh.runner.run.call_args.args[0]
 
 
-def test_create_codespace_omits_repo_when_none(tmp_path):
+def test_create_codespace_defaults_to_blank_repo_when_none(tmp_path):
+    # With no repo, `gh codespace create` would auto-detect from cwd and fail
+    # headlessly. Default to GitHub's blank template instead of guessing.
     gh = _gh(tmp_path)
-    gh.runner.run = MagicMock(return_value=_result(stdout="auto-detected-cs\n"))
+    gh.runner.run = MagicMock(return_value=_result(stdout="blank-cs\n"))
 
     gh.create_codespace()
 
-    assert "--repo" not in gh.runner.run.call_args.args[0]
+    cmd = gh.runner.run.call_args.args[0]
+    assert "--repo" in cmd
+    assert "github/codespaces-blank" in cmd
 
 
 def test_create_codespace_raises_when_no_name(tmp_path):


### PR DESCRIPTION
## Problem
`create_codespace` defaults `repo=None`, and `GitHubManager.create_codespace` only appends `--repo` when a repo is truthy. So a no-repo call runs a bare `gh codespace create`, which **auto-detects a repository from the current working directory**. Run headlessly (the cwd is not a Codespaces-enabled repo) that fails, and callers are left to guess a repo name.

## Fix
Default `repo` to **`github/codespaces-blank`** — GitHub's blank Ubuntu template. It needs no local repo, works headlessly, and matches the CLI path (`CodespaceSelector.BLANK_REPO`), so the MCP tool and CLI now behave consistently.

- `csproxy/github.py` — default `repo` to `github/codespaces-blank`; always pass `--repo`.
- `csproxy/mcp/server.py` — docstring reflects the new default.
- `tests/test_github.py` — replace the test that asserted the old omit-`--repo` behavior with one asserting the blank-repo default.

All github/codespace tests pass.
